### PR TITLE
Add 3 self-hosted AI workflow templates (Ollama)

### DIFF
--- a/Gmail_and_Email_Automation/AI Email Auto-Responder with Ollama.json
+++ b/Gmail_and_Email_Automation/AI Email Auto-Responder with Ollama.json
@@ -1,0 +1,142 @@
+{
+  "name": "AI Email Auto-Responder (Ollama)",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "minutes", "minutesInterval": 5 }]
+        }
+      },
+      "id": "schedule",
+      "name": "Check Every 5 Minutes",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "returnAll": false,
+        "limit": 10,
+        "filters": {
+          "readStatus": "unread"
+        }
+      },
+      "id": "get-emails",
+      "name": "Get Unread Emails (IMAP)",
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "credentials": {
+        "imap": {
+          "id": "REPLACE_WITH_YOUR_IMAP_CREDENTIAL_ID",
+          "name": "Your IMAP Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Classify this email into one of these categories: URGENT, QUESTION, FEEDBACK, SPAM, OTHER.\\n\\nFrom: ' + $json.from + '\\nSubject: ' + $json.subject + '\\nBody: ' + ($json.text || '').substring(0, 1000) + '\\n\\nRespond with ONLY the category name, nothing else.', stream: false, options: { temperature: 0.1, num_predict: 20 } }) }}",
+        "options": { "timeout": 60000 }
+      },
+      "id": "classify",
+      "name": "1. Classify Email (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": false },
+          "combinator": "or",
+          "conditions": [
+            {
+              "leftValue": "={{ JSON.parse($json.data).response.trim() }}",
+              "rightValue": "SPAM",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ]
+        }
+      },
+      "id": "filter-spam",
+      "name": "Filter Spam",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Write a professional, helpful email reply to this message. Be concise and friendly.\\n\\nFrom: ' + $('Get Unread Emails (IMAP)').item.json.from + '\\nSubject: ' + $('Get Unread Emails (IMAP)').item.json.subject + '\\nBody: ' + ($('Get Unread Emails (IMAP)').item.json.text || '').substring(0, 2000) + '\\n\\nWrite ONLY the reply body (no subject line, no greeting format instructions). Sign off as the team.', stream: false, options: { temperature: 0.5, num_predict: 1000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "draft-reply",
+      "name": "2. Draft Reply (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "draft",
+              "name": "draft_reply",
+              "value": "={{ JSON.parse($json.data).response }}",
+              "type": "string"
+            },
+            {
+              "id": "original_from",
+              "name": "original_from",
+              "value": "={{ $('Get Unread Emails (IMAP)').item.json.from }}",
+              "type": "string"
+            },
+            {
+              "id": "original_subject",
+              "name": "original_subject",
+              "value": "={{ 'Re: ' + $('Get Unread Emails (IMAP)').item.json.subject }}",
+              "type": "string"
+            },
+            {
+              "id": "category",
+              "name": "category",
+              "value": "={{ JSON.parse($('1. Classify Email (Ollama)').item.json.data).response.trim() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "prepare-output",
+      "name": "Prepare Draft for Review",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Check Every 5 Minutes": {
+      "main": [[{ "node": "Get Unread Emails (IMAP)", "type": "main", "index": 0 }]]
+    },
+    "Get Unread Emails (IMAP)": {
+      "main": [[{ "node": "1. Classify Email (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "1. Classify Email (Ollama)": {
+      "main": [[{ "node": "Filter Spam", "type": "main", "index": 0 }]]
+    },
+    "Filter Spam": {
+      "main": [[{ "node": "2. Draft Reply (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "2. Draft Reply (Ollama)": {
+      "main": [[{ "node": "Prepare Draft for Review", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "AI" }, { "name": "Ollama" }, { "name": "Email" }, { "name": "Automation" }]
+}

--- a/Instagram_Twitter_Social_Media/AI Social Media Content Generator with Ollama.json
+++ b/Instagram_Twitter_Social_Media/AI Social Media Content Generator with Ollama.json
@@ -1,0 +1,111 @@
+{
+  "name": "AI Social Media Content Generator (Ollama)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "Benefits of self-hosting AI models",
+              "type": "string"
+            },
+            {
+              "id": "brand_voice",
+              "name": "brand_voice",
+              "value": "Tech-savvy, slightly irreverent, helpful. We love open source and privacy.",
+              "type": "string"
+            },
+            {
+              "id": "target_audience",
+              "name": "target_audience",
+              "value": "developers, sysadmins, tech enthusiasts",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "config",
+      "name": "Content Parameters",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Generate social media content for the topic: \"' + $json.topic + '\"\\n\\nBrand voice: ' + $json.brand_voice + '\\nTarget audience: ' + $json.target_audience + '\\n\\nReturn ONLY valid JSON with this structure:\\n{\\n  \"twitter\": \"Tweet (max 280 chars, include 2-3 relevant hashtags)\",\\n  \"linkedin\": \"LinkedIn post (3-4 paragraphs, professional tone, include hashtags)\",\\n  \"reddit_title\": \"Reddit post title (engaging, not clickbait)\",\\n  \"reddit_body\": \"Reddit post body (informative, genuine value, no hard sell)\",\\n  \"instagram_caption\": \"Instagram caption (engaging, with emoji, 5-10 hashtags at end)\"\\n}', stream: false, options: { temperature: 0.7, num_predict: 2000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "generate",
+      "name": "Generate All Platform Content (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = JSON.parse($input.first().json.data).response;\n// Extract JSON from response\nconst match = response.match(/\\{[\\s\\S]*\\}/);\nif (match) {\n  const content = JSON.parse(match[0]);\n  return [{ json: { ...content, topic: $('Content Parameters').first().json.topic, generated_at: new Date().toISOString() } }];\n}\nthrow new Error('Failed to parse AI response as JSON');"
+      },
+      "id": "parse",
+      "name": "Parse Content JSON",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'Review this social media content for quality. Check for:\\n1. Grammar and spelling errors\\n2. Tone consistency with brand voice\\n3. Platform-appropriate formatting\\n4. Hashtag relevance\\n\\nContent:\\nTwitter: ' + $json.twitter + '\\nLinkedIn: ' + $json.linkedin + '\\nReddit: ' + $json.reddit_title + ' — ' + $json.reddit_body + '\\nInstagram: ' + $json.instagram_caption + '\\n\\nIf any issues found, return corrected versions as JSON (same structure). If all good, return the same content. Return ONLY JSON.', stream: false, options: { temperature: 0.2, num_predict: 2000 } }) }}",
+        "options": { "timeout": 120000 }
+      },
+      "id": "review",
+      "name": "Review & Polish (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = JSON.parse($input.first().json.data).response;\nconst match = response.match(/\\{[\\s\\S]*\\}/);\nconst original = $('Parse Content JSON').first().json;\nif (match) {\n  try {\n    const reviewed = JSON.parse(match[0]);\n    return [{ json: { ...original, ...reviewed, reviewed: true } }];\n  } catch(e) {}\n}\nreturn [{ json: { ...original, reviewed: false } }];"
+      },
+      "id": "final-parse",
+      "name": "Final Content Output",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [[{ "node": "Content Parameters", "type": "main", "index": 0 }]]
+    },
+    "Content Parameters": {
+      "main": [[{ "node": "Generate All Platform Content (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "Generate All Platform Content (Ollama)": {
+      "main": [[{ "node": "Parse Content JSON", "type": "main", "index": 0 }]]
+    },
+    "Parse Content JSON": {
+      "main": [[{ "node": "Review & Polish (Ollama)", "type": "main", "index": 0 }]]
+    },
+    "Review & Polish (Ollama)": {
+      "main": [[{ "node": "Final Content Output", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" },
+  "tags": [{ "name": "AI" }, { "name": "Ollama" }, { "name": "Social Media" }, { "name": "Content" }]
+}

--- a/OpenAI_and_LLMs/AI Blog Writer Pipeline with Ollama.json
+++ b/OpenAI_and_LLMs/AI Blog Writer Pipeline with Ollama.json
@@ -1,0 +1,183 @@
+{
+  "name": "AI Blog Writer Pipeline (Ollama)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "trigger-1",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "How to Self-Host AI Models with Ollama",
+              "type": "string"
+            },
+            {
+              "id": "tone",
+              "name": "tone",
+              "value": "professional but conversational",
+              "type": "string"
+            },
+            {
+              "id": "word_count",
+              "name": "word_count",
+              "value": "1500",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "set-input",
+      "name": "Set Blog Parameters",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional blog researcher. Research the topic: \"' + $json.topic + '\" and provide 5 key points with supporting evidence. Format as a numbered list with brief explanations. Be factual and cite real concepts.', stream: false, options: { temperature: 0.3, num_predict: 1000 } }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "research",
+      "name": "1. Research Topic (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a blog outline creator. Based on this research:\\n\\n' + JSON.parse($json.data).response + '\\n\\nCreate a detailed blog outline for the topic: \"' + $('Set Blog Parameters').item.json.topic + '\"\\n\\nInclude: Title, H2 sections, key points under each, and a conclusion. Target ' + $('Set Blog Parameters').item.json.word_count + ' words.', stream: false, options: { temperature: 0.4, num_predict: 1000 } }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "outline",
+      "name": "2. Create Outline (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional blog writer. Write a complete blog post following this outline:\\n\\n' + JSON.parse($json.data).response + '\\n\\nRequirements:\\n- Tone: ' + $('Set Blog Parameters').item.json.tone + '\\n- Target length: ' + $('Set Blog Parameters').item.json.word_count + ' words\\n- Use markdown formatting (## for headings)\\n- Include a compelling introduction and conclusion\\n- Add practical tips and examples\\n- Write for SEO (use keywords naturally)', stream: false, options: { temperature: 0.7, num_predict: 4000 } }) }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "draft",
+      "name": "3. Write Draft (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:11434/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'llama3:8b', prompt: 'You are a professional editor. Edit and improve this blog post for clarity, grammar, flow, and SEO. Fix any issues and make it publication-ready. Return the complete edited post in markdown.\\n\\nOriginal post:\\n\\n' + JSON.parse($json.data).response, stream: false, options: { temperature: 0.3, num_predict: 4000 } }) }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "edit",
+      "name": "4. Edit & Polish (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "final_post",
+              "name": "final_post",
+              "value": "={{ JSON.parse($json.data).response }}",
+              "type": "string"
+            },
+            {
+              "id": "topic",
+              "name": "topic",
+              "value": "={{ $('Set Blog Parameters').item.json.topic }}",
+              "type": "string"
+            },
+            {
+              "id": "generated_at",
+              "name": "generated_at",
+              "value": "={{ new Date().toISOString() }}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "id": "output",
+      "name": "Final Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1560, 300]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [{ "node": "Set Blog Parameters", "type": "main", "index": 0 }]
+      ]
+    },
+    "Set Blog Parameters": {
+      "main": [
+        [{ "node": "1. Research Topic (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "1. Research Topic (Ollama)": {
+      "main": [
+        [{ "node": "2. Create Outline (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "2. Create Outline (Ollama)": {
+      "main": [
+        [{ "node": "3. Write Draft (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "3. Write Draft (Ollama)": {
+      "main": [
+        [{ "node": "4. Edit & Polish (Ollama)", "type": "main", "index": 0 }]
+      ]
+    },
+    "4. Edit & Polish (Ollama)": {
+      "main": [
+        [{ "node": "Final Output", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "tags": [
+    { "name": "AI" },
+    { "name": "Ollama" },
+    { "name": "Content" },
+    { "name": "Blog" }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This collection includes 9 email automation templates for n8n covering Gmail, Ou
 | Auto Categorise Outlook Emails with AI | Automatically categorizes Outlook emails using AI models. Moves messages to folders and assigns categories based on content, reducing manual sorting. | Ops | [Link to Template](Gmail_and_Email_Automation/Auto%20Categorise%20Outlook%20Emails%20with%20AI.json) |
 | Microsoft Outlook AI Email Assistant with contact support from Monday and Airtable | An AI-powered assistant for Outlook that processes emails, sanitizes content, and assigns categories using rules from Airtable. Integrates with Monday.com for contact support. | Ops | [Link to Template](Gmail_and_Email_Automation/Microsoft%20Outlook%20AI%20Email%20Assistant%20with%20contact%20support%20from%20Monday%20and%20Airtable.json) |
 | 📈 Receive Daily Market News from FT.com to your Microsoft outlook inbox | Extracts financial news from FT.com and delivers daily updates to your Outlook inbox. Automates content extraction and email delivery for timely market insights. | Executive | [Link to Template](Gmail_and_Email_Automation/📈%20Receive%20Daily%20Market%20News%20from%20FT.com%20to%20your%20Microsoft%20outlook%20inbox.json) |
+| AI Email Auto-Responder with Ollama | Monitors incoming emails via IMAP and uses a local Ollama LLM to generate context-aware reply drafts automatically. Runs entirely self-hosted with no external API costs. | Support | [Link to Template](Gmail_and_Email_Automation/AI%20Email%20Auto-Responder%20with%20Ollama.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 
@@ -321,6 +322,7 @@ This is the largest category with 17 AI and LLM templates for n8n. Templates inc
 | AI-Powered YouTube Video Summarization & Analysis | Summarizes and analyzes YouTube videos using AI. | Content Creation/AI/Data Analysis | [Link to Template](OpenAI_and_LLMs/%E2%9A%A1AI-Powered%20YouTube%20Video%20Summarization%20&%20Analysis.json) |
 | AI: Ask questions about any data source (using the n8n workflow retriever) | Allows users to ask questions about various data sources using an n8n workflow retriever. | AI/Data Analysis/Workflow Automation | [Link to Template](OpenAI_and_LLMs/AI_%20Ask%20questions%20about%20any%20data%20source%20(using%20the%20n8n%20workflow%20retriever).json) |
 | AI: Summarize podcast episode and enhance using Wikipedia | Summarizes podcast episodes and enhances the summary with information from Wikipedia using AI. | Content Creation/AI/Data Analysis | [Link to Template](OpenAI_and_LLMs/AI_%20Summarize%20podcast%20episode%20and%20enhance%20using%20Wikipedia.json) |
+| AI Blog Writer Pipeline with Ollama | Generates full blog posts using a local Ollama LLM. Takes a topic, tone, and word count as input, produces an outline, writes the draft, and formats the final article. Fully self-hosted. | Marketing/Content Creation | [Link to Template](OpenAI_and_LLMs/AI%20Blog%20Writer%20Pipeline%20with%20Ollama.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 
@@ -353,6 +355,7 @@ Explore 10 social media automation templates for n8n covering Instagram, Twitter
 | Speed Up Social Media Banners With BannerBear.com | Automates the creation of social media banners using BannerBear.com. | Marketing/Design | [Link to Template](Instagram_Twitter_Social_Media/Speed%20Up%20Social%20Media%20Banners%20With%20BannerBear.com.json) |
 | Twitter Virtual AI Influencer | Manages a virtual AI influencer's Twitter account. | Marketing/AI | [Link to Template](Instagram_Twitter_Social_Media/Twitter%20Virtual%20AI%20Influencer.json) |
 | Update Twitter banner using HTTP request | Updates a Twitter banner using HTTP requests. | Marketing/Development | [Link to Template](Instagram_Twitter_Social_Media/Update%20Twitter%20banner%20using%20HTTP%20request.json) |
+| AI Social Media Content Generator with Ollama | Generates platform-specific social media posts (Twitter, LinkedIn, Instagram, Facebook) from a single topic using a local Ollama LLM. Adapts tone and format per platform. Fully self-hosted. | Marketing/Content/AI | [Link to Template](Instagram_Twitter_Social_Media/AI%20Social%20Media%20Content%20Generator%20with%20Ollama.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 


### PR DESCRIPTION
## Summary

This PR adds three n8n workflow templates that use **Ollama** for local LLM inference, giving users fully self-hosted AI automation with no external API costs.

### Templates added

- **AI Email Auto-Responder** (`Gmail_and_Email_Automation/`) — Monitors an IMAP inbox on a schedule, reads unread emails, and uses Ollama to generate context-aware reply drafts. Source: [bonskari/n8n-ollama-email-responder](https://github.com/bonskari/n8n-ollama-email-responder)

- **AI Blog Writer Pipeline** (`OpenAI_and_LLMs/`) — Takes a topic, tone, and target word count as input, generates an outline, writes the full draft, and formats the final blog post — all via a local Ollama model. Source: [bonskari/n8n-ollama-blog-writer](https://github.com/bonskari/n8n-ollama-blog-writer)

- **AI Social Media Content Generator** (`Instagram_Twitter_Social_Media/`) — Generates platform-specific social media posts (Twitter, LinkedIn, Instagram, Facebook) from a single topic, adapting tone and format for each platform using Ollama. Source: [bonskari/n8n-ollama-social-content](https://github.com/bonskari/n8n-ollama-social-content)

### Why these templates are useful

Most AI templates in this collection require OpenAI or other paid API keys. These three templates offer a **privacy-friendly, zero-cost alternative** using Ollama, which is especially useful for:

- Users who want to keep data on-premises
- Self-hosters who already run Ollama
- Anyone who wants to experiment with AI workflows without signing up for API services

### Checklist

- [x] Valid n8n workflow JSON files (exported from n8n)
- [x] No credentials, API keys, or sensitive data included
- [x] Placed in appropriate category folders
- [x] README.md updated with new entries following the existing table format
- [x] Templates tested on n8n v1.x