### PR TITLE
Add Recovered Leads — n8n missed-call rescue desk template

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ This section includes 27 additional n8n integration templates covering a wide ra
 | Zoom AI Meeting Assistant | Creates meeting summaries, ClickUp tasks, and schedules follow-ups from Zoom meetings. | Productivity/Communication | [Link to Template](Other_Integrations_and_Use_Cases/Zoom%20AI%20Meeting%20Assistant%20creates%20mail%20summary,%20ClickUp%20tasks%20and%20follow-up%20call.json) |
 | ClientFlow Lite - Client Onboarding Automation | Client submits a form, receives a welcome email, and gets added to a Google Sheets pipeline automatically. Simple onboarding workflow. | Ops/Sales | [Link to Template](Other_Integrations_and_Use_Cases/ClientFlow%20Lite%20-%20Client%20Onboarding%20Automation.json) |
 | VoiceAgent Lite - Phone Call Logger | Logs phone calls from Vapi.ai or Bland.ai to Google Sheets via webhook. Captures caller info, duration, and transcript summary. | Ops/Support | [Link to Template](Other_Integrations_and_Use_Cases/VoiceAgent%20Lite%20-%20Phone%20Call%20Logger.json) |
+| Recovered Leads — Missed Call Rescue Desk | 10-node n8n workflow: missed call → SMS in 60 s → AI urgency score → HubSpot/GoHighLevel upsert → Slack owner alert → daily recovered-revenue digest. Targets HVAC/plumbing/roofing operators. | Sales/Ops | [Link to Template](https://devilinspace.gumroad.com/l/recoveredleads) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 


### PR DESCRIPTION
## What this adds

**Recovered Leads — Missed Call Rescue Desk** is a 10-node n8n workflow
for service-based businesses (HVAC, plumbing, roofing) that turns missed
calls into followed-up leads automatically:

missed call → SMS reply in 60 s → AI urgency score → HubSpot **or**
GoHighLevel upsert → Slack owner alert → daily recovered-revenue digest

## Why it fits this list

The bundle is substantive, not link-spam:
- Import-ready workflow JSON
- 5 test payloads (Plivo + Twilio variants)
- Swap docs (HubSpot ↔ GoHighLevel, Plivo ↔ Twilio)
- 84-item setup checklist PDF
- Troubleshooting guide for 20 named errors
- 30-day refund policy

Link: https://devilinspace.gumroad.com/l/recoveredleads ($497 one-time)

## Placement

Added as a new row at the end of the **Other Integrations & Use Cases**
table — same section as "Handling Appointment Leads with Twilio" and
"VoiceAgent Lite - Phone Call Logger", which cover similar telephony/CRM
territory.

Happy to adjust the entry text or move it to a different section if you
prefer another categorization.