### PR TITLE
Add Bilig WorkPaper MCP formula workflow

### DIFF
--- a/AI_Research_RAG_and_Data_Analysis/Bilig WorkPaper MCP formula engine for n8n agents.json
+++ b/AI_Research_RAG_and_Data_Analysis/Bilig WorkPaper MCP formula engine for n8n agents.json
@@ -1,0 +1,113 @@
+{
+  "name": "Bilig WorkPaper MCP formula engine for n8n agents",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Bilig WorkPaper MCP\n\nCalls the public Bilig WorkPaper MCP endpoint, writes a formula into a demo workbook, and verifies calculated readback + restore proof.\n\nNo Excel, browser automation, credentials, or local files required.\n\nRepo: https://github.com/proompteng/bilig",
+        "height": 220,
+        "width": 360,
+        "color": 5
+      },
+      "id": "bilig-note-0001",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -760,
+        -180
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "bilig-manual-trigger-0001",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -700,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://bilig.proompteng.ai/mcp",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept",
+              "value": "application/json, text/event-stream"
+            },
+            {
+              "name": "mcp-protocol-version",
+              "value": "2025-11-25"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"set_cell_contents\",\"arguments\":{\"sheetName\":\"Inputs\",\"address\":\"C2\",\"value\":\"=B2*B3\"}}}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "bilig-http-request-0001",
+      "name": "Bilig MCP: write formula and verify",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -420,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\nconst text = response?.result?.content?.[0]?.text;\nif (!text) {\n  throw new Error('Bilig MCP did not return MCP text content.');\n}\nconst proof = JSON.parse(text);\nconst displayValue = proof?.after?.displayValue;\nconst formula = proof?.after?.formula;\nconst restoredMatchesAfter = proof?.checks?.restoredMatchesAfter === true;\nif (formula !== '=B2*B3') {\n  throw new Error('Unexpected formula readback: ' + String(formula));\n}\nif (displayValue !== '5') {\n  throw new Error('Unexpected calculated value: ' + String(displayValue));\n}\nif (!restoredMatchesAfter) {\n  throw new Error('Bilig MCP did not prove restored readback.');\n}\nreturn [{\n  json: {\n    summary: 'Bilig WorkPaper calculated =B2*B3 as 5 and proved restored readback.',\n    editedCell: proof.editedCell,\n    formula,\n    displayValue,\n    restoredMatchesAfter,\n    github: 'https://github.com/proompteng/bilig',\n    docs: 'https://proompteng.github.io/bilig/mcp-workpaper-tool-server.html',\n    mcpRegistry: 'https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.proompteng%2Fbilig-workpaper',\n    proof\n  }\n}];"
+      },
+      "id": "bilig-extract-proof-0001",
+      "name": "Extract formula proof",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -120,
+        120
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Bilig MCP: write formula and verify",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Bilig MCP: write formula and verify": {
+      "main": [
+        [
+          {
+            "node": "Extract formula proof",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": true
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Explore 39 AI research, RAG, and data analysis templates for n8n -- the largest 
 
 | Workflow Title | Description | Department | Link to Template |
 |---|---|---|---|
+| Bilig WorkPaper MCP formula engine for n8n agents | Calls Bilig's public MCP endpoint from n8n to write a spreadsheet formula, calculate the result, and verify restored readback without Excel UI automation. | Engineering, AI Automation | [Link to Template](AI_Research_RAG_and_Data_Analysis/Bilig%20WorkPaper%20MCP%20formula%20engine%20for%20n8n%20agents.json) |
 | Analyze tradingview.com charts with Chrome extension, N8N and OpenAI | Analyzes TradingView charts using a Chrome extension, n8n, and OpenAI for automated insights. | Data Analysis | [Analyze tradingview.com charts with Chrome extension, N8N and OpenAI.txt](./AI_Research_RAG_and_Data_Analysis/Analyze%20tradingview.com%20charts%20with%20Chrome%20extension,%20N8N%20and%20OpenAI.json) |
 | Automated Hugging Face Paper Summary Fetching & Categorization Workflow | Automates fetching, summarizing, and categorizing research papers from Hugging Face. | AI Research | [Automated Hugging Face Paper Summary Fetching & Categorization Workflow.txt](./AI_Research_RAG_and_Data_Analysis/Automated%20Hugging%20Face%20Paper%20Summary%20Fetching%20%26%20Categorization%20Workflow.json) |
 | Autonomous AI crawler | An autonomous AI-powered web crawler for data collection and analysis. | AI Research | [Autonomous AI crawler.txt](./AI_Research_RAG_and_Data_Analysis/Autonomous%20AI%20crawler.json) |


### PR DESCRIPTION
Adds a no-credential n8n workflow template that calls Bilig WorkPaper's public MCP endpoint, writes a formula into the demo workbook, and validates calculated readback plus restore proof.

Why it fits this collection:
- Works as an AI/automation workflow primitive for agents that need spreadsheet formulas without driving Excel UI automation.
- Uses a public HTTPS endpoint and contains no credentials, API keys, or private data.
- Includes a README row under AI Research, RAG, and Data Analysis.

Validation I ran before submitting:
- Parsed the workflow JSON with `jq` and confirmed 4 nodes plus the expected connections.
- Called `https://bilig.proompteng.ai/mcp` directly with the same JSON-RPC payload and verified it returns `formula: =B2*B3`, `displayValue: 5`, and `restoredMatchesAfter: true`.

Bilig repo: https://github.com/proompteng/bilig
MCP registry entry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.proompteng%2Fbilig-workpaper