### PR TITLE
Add Komos regulated browser ops template

### DIFF
--- a/Other_Integrations_and_Use_Cases/Komos Regulated Browser Ops Task Queue.json
+++ b/Other_Integrations_and_Use_Cases/Komos Regulated Browser Ops Task Queue.json
@@ -1,0 +1,215 @@
+{
+  "name": "Komos Regulated Browser Ops Task Queue",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        160,
+        360
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "task-id",
+              "name": "task_id",
+              "value": "={{ $env.KOMOS_TASK_ID || 'replace-with-komos-task-id' }}",
+              "type": "string"
+            },
+            {
+              "id": "case-id",
+              "name": "case_id",
+              "value": "CRA-DEMO-001",
+              "type": "string"
+            },
+            {
+              "id": "workflow-type",
+              "name": "workflow_type",
+              "value": "background_screening_portal_check",
+              "type": "string"
+            },
+            {
+              "id": "industry",
+              "name": "industry",
+              "value": "background_screening",
+              "type": "string"
+            },
+            {
+              "id": "applicant-name",
+              "name": "applicant_name",
+              "value": "Example Applicant",
+              "type": "string"
+            },
+            {
+              "id": "portal-url",
+              "name": "portal_url",
+              "value": "https://example-portal.local/cases/CRA-DEMO-001",
+              "type": "string"
+            },
+            {
+              "id": "review-required",
+              "name": "review_required",
+              "value": true,
+              "type": "boolean"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "build-case-payload",
+      "name": "Build Regulated Ops Payload",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        420,
+        360
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ 'https://api.komos.ai/public/v1/tasks/' + ($env.KOMOS_TASK_ID || $json.task_id) + '/runs' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ 'Bearer ' + $env.KOMOS_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"clientRequestId\": \"n8n-{{ $json.case_id }}-{{ Date.now() }}\",\n  \"inputs\": {\n    \"case_id\": \"{{ $json.case_id }}\",\n    \"workflow_type\": \"{{ $json.workflow_type }}\",\n    \"applicant_name\": \"{{ $json.applicant_name }}\",\n    \"portal_url\": \"{{ $json.portal_url }}\",\n    \"review_required\": {{ $json.review_required }}\n  },\n  \"metadata\": {\n    \"source\": \"n8n\",\n    \"use_case\": \"regulated_browser_operations\",\n    \"industry\": \"{{ $json.industry }}\"\n  }\n}",
+        "options": {}
+      },
+      "id": "queue-komos-task",
+      "name": "Queue Komos Task Run",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        700,
+        360
+      ],
+      "retryOnFail": true,
+      "maxTries": 2
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "status",
+              "name": "status",
+              "value": "queued",
+              "type": "string"
+            },
+            {
+              "id": "komos_response",
+              "name": "komos_response",
+              "value": "={{ $json }}",
+              "type": "object"
+            },
+            {
+              "id": "next-step",
+              "name": "next_step",
+              "value": "Review the Komos run history for browser actions, logs, and any human approval checkpoint.",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "format-response",
+      "name": "Format Queue Response",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        980,
+        360
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Komos Regulated Browser Ops Task Queue\n\nUse this template to queue a Komos task from n8n when a CRA, bank, or insurance ops workflow needs browser portal work.\n\nSet these environment variables before running:\n\nKOMOS_API_KEY\nKOMOS_TASK_ID\n\nAPI docs: https://docs.komos.ai/api-reference/introduction\nBackground screening example: https://www.komos.ai/solutions/hr",
+        "height": 260,
+        "width": 380,
+        "color": 5
+      },
+      "id": "setup-note",
+      "name": "Setup Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        120,
+        80
+      ]
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Build Regulated Ops Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Regulated Ops Payload": {
+      "main": [
+        [
+          {
+            "node": "Queue Komos Task Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Queue Komos Task Run": {
+      "main": [
+        [
+          {
+            "node": "Format Queue Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true
+  },
+  "tags": [
+    {
+      "name": "Komos",
+      "id": "komos"
+    },
+    {
+      "name": "Regulated Ops",
+      "id": "regulated-ops"
+    },
+    {
+      "name": "Browser Automation",
+      "id": "browser-automation"
+    }
+  ],
+  "meta": {
+    "instanceId": "komos-regulated-browser-ops-v1"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Explore 10 social media automation templates for n8n covering Instagram, Twitter
 
 ### What other n8n integration templates are available?
 
-This section includes 27 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
+This section includes 28 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -386,6 +386,7 @@ This section includes 27 additional n8n integration templates covering a wide ra
 | Integrating AI with Open-Meteo API | Enhances weather forecasting with AI analysis. | Data Science/Weather | [Link to Template](Other_Integrations_and_Use_Cases/Integrating%20AI%20with%20Open-Meteo%20API%20for%20Enhanced%20Weather%20Forecasting.json) |
 | Introduction to the HTTP Tool | Basic tutorial on using HTTP tools in n8n. | Development | [Link to Template](Other_Integrations_and_Use_Cases/Introduction%20to%20the%20HTTP%20Tool.json) |
 | KB Tool - Confluence Knowledge Base | Integrates with Confluence for knowledge base management. | Documentation/IT | [Link to Template](Other_Integrations_and_Use_Cases/KB%20Tool%20-%20Confluence%20Knowledge%20Base.json) |
+| Komos Regulated Browser Ops Task Queue | Queues a [Komos](https://www.komos.ai/) browser automation task from n8n for CRA, banking, or insurance portal operations with audit-ready run metadata. | Ops/Compliance | [Link to Template](Other_Integrations_and_Use_Cases/Komos%20Regulated%20Browser%20Ops%20Task%20Queue.json) |
 | LINE Assistant with Google Calendar and Gmail | Creates a LINE assistant that integrates with Google Calendar and Gmail. | Productivity/Communication | [Link to Template](Other_Integrations_and_Use_Cases/LINE%20Assistant%20with%20Google%20Calendar%20and%20Gmail%20Integration.json) |
 | Monthly Spotify Track Archiving | Archives and classifies monthly Spotify tracks into playlists. | Personal/Music | [Link to Template](Other_Integrations_and_Use_Cases/Monthly%20Spotify%20Track%20Archiving%20and%20Playlist%20Classification.json) |
 | Obsidian Notes Read Aloud | Converts Obsidian notes into audio format as a podcast feed. | Productivity/Content | [Link to Template](Other_Integrations_and_Use_Cases/Obsidian%20Notes%20Read%20Aloud%20using%20AI_%20Available%20as%20a%20Podcast%20Feed.json) |


### PR DESCRIPTION
Adds a Komos template for queueing regulated browser-operations task runs from n8n. The example is aimed at CRA, banking, and insurance portal workflows where n8n can hand off the browser work to a Komos task and keep run metadata for review.\n\nWhat changed:\n\n- Added a new workflow JSON in Other_Integrations_and_Use_Cases.\n- Added a README table row and updated the section count.\n- Uses environment variables for KOMOS_API_KEY and KOMOS_TASK_ID, no secrets or credentials included.\n\nValidation:\n\n- Ran jq empty on the workflow JSON.\n- Ran git diff --check.\n- Checked the linked Komos docs and examples return 200.\n\nDisclosure: I am affiliated with Komos.