### PR TITLE
Add SAP & Enterprise ERP category with Purchase Order Auto-Sync template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
   - [Other Integrations & Use Cases](#what-other-n8n-integration-templates-are-available)
   - [Forms & Surveys](#how-do-i-automate-forms-and-surveys-with-n8n)
   - [AI Research, RAG, and Data Analysis](#what-n8n-templates-exist-for-ai-research-rag-and-data-analysis)
+  - [SAP & Enterprise ERP](#what-n8n-templates-are-available-for-sap-and-enterprise-erp)
   - [Other](#other)
 - [FAQ](#faq)
 - [Contributing](#contributing)
@@ -466,6 +467,16 @@ Explore 39 AI research, RAG, and data analysis templates for n8n -- the largest 
 | 🔍 Perplexity Research to HTML: AI-Powered Content Creation | Transforms Perplexity AI research into HTML content for AI-powered content creation. | Content Creation, AI Research | [🔍 Perplexity Research to HTML_ AI-Powered Content Creation.txt](./AI_Research_RAG_and_Data_Analysis/%F0%9F%94%8D%20Perplexity%20Research%20to%20HTML_%20AI-Powered%20Content%20Creation.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
+
+### What n8n templates are available for SAP and Enterprise ERP?
+
+> Connect SAP S/4HANA and SAP ECC to n8n for enterprise automation. Requires [n8n-nodes-sap-odata](https://github.com/sseegebarth/n8n-nodes-sap-odata) community node.
+
+| Template Title | Description | Department | Link |
+|---|---|---|---|
+| SAP Purchase Order Auto-Sync | Daily sync new SAP Purchase Orders to Google Sheets with Slack notifications. Free template. | Procurement, Operations | [SAP Purchase Order Auto-Sync.json](./SAP_and_Enterprise/SAP%20Purchase%20Order%20Auto-Sync.json) |
+
+> 💡 More SAP templates (Invoice OCR, Inventory Alerts, HR Onboarding, Report Automation) available at [n8n-sap-templates](https://github.com/bladeJumper/n8n-sap-templates)
 
 ### Other
 

--- a/SAP_and_Enterprise/SAP Purchase Order Auto-Sync.json
+++ b/SAP_and_Enterprise/SAP Purchase Order Auto-Sync.json
@@ -1,0 +1,154 @@
+{
+  "name": "SAP Purchase Order Auto-Sync to Google Sheets",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "hours",
+              "hoursInterval": 24
+            }
+          ],
+          "timezone": "Asia/Shanghai"
+        }
+      },
+      "id": "trigger-1",
+      "name": "Daily at 8AM",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "basicAuth",
+        "resource": "entity",
+        "operation": "getAll",
+        "servicePath": "/sap/opu/odata/sap/API_PURCHASEORDER_PROCESS_SRV",
+        "entitySet": "A_PurchaseOrder",
+        "queryOptions": {
+          "$filter": "CreationDate ge datetime'{{ $now.minus({days:1}).toFormat('yyyy-MM-dd') }}T00:00:00'",
+          "$select": "PurchaseOrder,PurchaseOrderType,Supplier,CompanyCode,TotalNetAmount,Currency,CreationDate",
+          "$orderby": "CreationDate desc"
+        },
+        "returnAll": true
+      },
+      "id": "sap-1",
+      "name": "Get New POs from SAP",
+      "type": "n8n-nodes-sap-odata.sapOdata",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ],
+      "credentials": {
+        "sapOdataApi": {
+          "id": "CONFIGURE_ME",
+          "name": "SAP OData API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "mode": "url",
+          "value": "YOUR_GOOGLE_SHEET_ID"
+        },
+        "sheetName": "PurchaseOrders",
+        "columns": {
+          "mappingMode": "autoMapInputData",
+          "value": {
+            "PO_Number": "={{ $json.PurchaseOrder }}",
+            "PO_Type": "={{ $json.PurchaseOrderType }}",
+            "Supplier": "={{ $json.Supplier }}",
+            "Company": "={{ $json.CompanyCode }}",
+            "Amount": "={{ $json.TotalNetAmount }}",
+            "Currency": "={{ $json.Currency }}",
+            "Created": "={{ $json.CreationDate }}"
+          }
+        }
+      },
+      "id": "sheets-1",
+      "name": "Append to Google Sheets",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.5,
+      "position": [
+        650,
+        300
+      ],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "CONFIGURE_ME",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "channel": "#procurement",
+        "text": "=\ud83d\udcca {{ $items('Get New POs from SAP').length }} new Purchase Orders synced from SAP\\nTotal Value: {{ $sum($items('Get New POs from SAP').json.TotalNetAmount).toFixed(2) }} {{ $items('Get New POs from SAP')[0].json.Currency }}\\nView in Google Sheets: https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID"
+      },
+      "id": "slack-1",
+      "name": "Slack Notification",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.2,
+      "position": [
+        850,
+        300
+      ],
+      "credentials": {
+        "slackApi": {
+          "id": "CONFIGURE_ME",
+          "name": "Slack account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Daily at 8AM": {
+      "main": [
+        [
+          {
+            "node": "Get New POs from SAP",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get New POs from SAP": {
+      "main": [
+        [
+          {
+            "node": "Append to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Append to Google Sheets": {
+      "main": [
+        [
+          {
+            "node": "Slack Notification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "templateId": "sap-po-sync-001",
+    "category": "SAP Procurement",
+    "author": "SAP Consultant",
+    "price": "free",
+    "description": "Automatically sync new SAP Purchase Orders to Google Sheets daily with Slack notifications"
+  }
+}


### PR DESCRIPTION
## New Category: SAP & Enterprise ERP

This PR adds the first SAP template to the collection, creating a new category for enterprise ERP automation.

### Template Added
- **SAP Purchase Order Auto-Sync** - Daily sync new SAP Purchase Orders to Google Sheets with Slack notifications

### Why This Category?
- n8n has 35.8K monthly downloads but **zero SAP templates** in the official collection
- The [n8n-nodes-sap-odata](https://github.com/sseegebarth/n8n-nodes-sap-odata) community node has 246 monthly downloads, proving demand exists
- SAP is the world's largest ERP system (400K+ customers) - this is a massive untapped market for n8n automation

### Prerequisites
- [n8n-nodes-sap-odata](https://github.com/sseegebarth/n8n-nodes-sap-odata) community node
- SAP OData service enabled (SAP Gateway)
- SAP user credentials

### More Templates
Additional SAP templates (Invoice OCR, Inventory Alerts, HR Onboarding, Report Automation) are available at [n8n-sap-templates](https://github.com/bladeJumper/n8n-sap-templates)