### PR TITLE
Add Tunova templates: generate Suno AI music (form + webhook)

### DIFF
--- a/Forms_and_Surveys/Tunova - Generate a song from a form.json
+++ b/Forms_and_Surveys/Tunova - Generate a song from a form.json
@@ -1,0 +1,141 @@
+{
+  "id": "tunovaFormToSong",
+  "name": "Tunova — Generate a song from a form",
+  "nodes": [
+    {
+      "parameters": {
+        "formTitle": "Make a song with AI",
+        "formDescription": "Describe the track you want — Tunova generates it with Suno (v5.5).",
+        "formFields": {
+          "values": [
+            {
+              "fieldLabel": "Prompt",
+              "placeholder": "calm rainy-night lofi, mellow piano, vinyl crackle",
+              "requiredField": true
+            },
+            {
+              "fieldLabel": "Instrumental",
+              "fieldType": "dropdown",
+              "fieldOptions": {
+                "values": [
+                  { "option": "No" },
+                  { "option": "Yes" }
+                ]
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.formTrigger",
+      "typeVersion": 2.2,
+      "position": [0, 0],
+      "id": "11111111-1111-4111-8111-111111111111",
+      "name": "On form submission",
+      "webhookId": "tunova-song-form"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.tunova.ai/api/generate",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"prompt\": {{ JSON.stringify($json.Prompt) }},\n  \"instrumental\": {{ $json.Instrumental === 'Yes' }}\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [220, 0],
+      "id": "22222222-2222-4222-8222-222222222222",
+      "name": "Tunova: start generation",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_TUNOVA_CREDENTIAL",
+          "name": "Tunova API key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "amount": 120,
+        "unit": "seconds"
+      },
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [440, 0],
+      "id": "33333333-3333-4333-8333-333333333333",
+      "name": "Wait for render (~2 min)",
+      "webhookId": "tunova-song-wait"
+    },
+    {
+      "parameters": {
+        "url": "=https://api.tunova.ai/api/jobs/{{ $('Tunova: start generation').item.json.job_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 0],
+      "id": "44444444-4444-4444-8444-444444444444",
+      "name": "Tunova: get result",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_TUNOVA_CREDENTIAL",
+          "name": "Tunova API key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "status",
+              "value": "={{ $json.status }}",
+              "type": "string"
+            },
+            {
+              "id": "a2",
+              "name": "audio_url",
+              "value": "={{ $json.clips?.[0]?.audio_url }}",
+              "type": "string"
+            },
+            {
+              "id": "a3",
+              "name": "title",
+              "value": "={{ $json.clips?.[0]?.title }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [880, 0],
+      "id": "55555555-5555-4555-8555-555555555555",
+      "name": "Your track"
+    }
+  ],
+  "connections": {
+    "On form submission": {
+      "main": [[{ "node": "Tunova: start generation", "type": "main", "index": 0 }]]
+    },
+    "Tunova: start generation": {
+      "main": [[{ "node": "Wait for render (~2 min)", "type": "main", "index": 0 }]]
+    },
+    "Wait for render (~2 min)": {
+      "main": [[{ "node": "Tunova: get result", "type": "main", "index": 0 }]]
+    },
+    "Tunova: get result": {
+      "main": [[{ "node": "Your track", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" },
+  "pinData": {},
+  "meta": {}
+}

--- a/Other_Integrations_and_Use_Cases/Tunova - Generate a song via webhook.json
+++ b/Other_Integrations_and_Use_Cases/Tunova - Generate a song via webhook.json
@@ -1,0 +1,92 @@
+{
+  "id": "tunovaWebhookToSong",
+  "name": "Tunova — Generate a song via webhook (drop-in API)",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "generate-song",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 0],
+      "id": "a1111111-1111-4111-8111-111111111111",
+      "name": "POST /generate-song",
+      "webhookId": "tunova-generate-song"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.tunova.ai/api/generate",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"prompt\": {{ JSON.stringify($json.body.prompt) }},\n  \"instrumental\": {{ $json.body.instrumental === true }}\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [220, 0],
+      "id": "a2222222-2222-4222-8222-222222222222",
+      "name": "Tunova: start generation",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_TUNOVA_CREDENTIAL",
+          "name": "Tunova API key"
+        }
+      }
+    },
+    {
+      "parameters": { "amount": 150, "unit": "seconds" },
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [440, 0],
+      "id": "a3333333-3333-4333-8333-333333333333",
+      "name": "Wait for render",
+      "webhookId": "tunova-webhook-wait"
+    },
+    {
+      "parameters": {
+        "url": "=https://api.tunova.ai/api/jobs/{{ $('Tunova: start generation').item.json.job_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 0],
+      "id": "a4444444-4444-4444-8444-444444444444",
+      "name": "Tunova: get result",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_TUNOVA_CREDENTIAL",
+          "name": "Tunova API key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\n  \"status\": {{ JSON.stringify($json.status) }},\n  \"audio_url\": {{ JSON.stringify($json.clips?.[0]?.audio_url ?? null) }},\n  \"title\": {{ JSON.stringify($json.clips?.[0]?.title ?? null) }}\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 0],
+      "id": "a5555555-5555-4555-8555-555555555555",
+      "name": "Return audio URL"
+    }
+  ],
+  "connections": {
+    "POST /generate-song": { "main": [[{ "node": "Tunova: start generation", "type": "main", "index": 0 }]] },
+    "Tunova: start generation": { "main": [[{ "node": "Wait for render", "type": "main", "index": 0 }]] },
+    "Wait for render": { "main": [[{ "node": "Tunova: get result", "type": "main", "index": 0 }]] },
+    "Tunova: get result": { "main": [[{ "node": "Return audio URL", "type": "main", "index": 0 }]] }
+  },
+  "settings": { "executionOrder": "v1" },
+  "pinData": {},
+  "meta": {}
+}

--- a/README.md
+++ b/README.md
@@ -376,11 +376,12 @@ Explore 13 social media automation templates for n8n covering Instagram, Twitter
 
 ### What other n8n integration templates are available?
 
-This section includes 28 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
+This section includes 29 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
 | API Schema Extractor | Extracts API schemas from web services for documentation or integration purposes. | Development/Integration | [Link to Template](Other_Integrations_and_Use_Cases/API%20Schema%20Extractor.json) |
+| Generate a Song via Webhook (Tunova / Suno API) | POST a prompt to a webhook and get back a finished Suno AI music track (audio URL) — a drop-in music-generation endpoint for your app. Core HTTP node; free API key at tunova.ai. | Engineering/Creative | [Link to Template](Other_Integrations_and_Use_Cases/Tunova%20-%20Generate%20a%20song%20via%20webhook.json) |
 | Analyze feedback and send a message on Mattermost | Analyzes user feedback and sends notifications to Mattermost channels. | Support/Communication | [Link to Template](Other_Integrations_and_Use_Cases/Analyze%20feedback%20and%20send%20a%20message%20on%20Mattermost.json) |
 | Analyze feedback using AWS Comprehend | Performs sentiment analysis on feedback using AWS Comprehend and sends results to Mattermost. | Support/AI | [Link to Template](Other_Integrations_and_Use_Cases/Analyze%20feedback%20using%20AWS%20Comprehend%20and%20send%20it%20to%20a%20Mattermost%20channel.json) |
 | Automate Pinterest Analysis & AI-Powered Content Suggestions | Analyzes Pinterest data and provides AI-powered content suggestions. | Marketing/AI | [Link to Template](Other_Integrations_and_Use_Cases/Automate%20Pinterest%20Analysis%20%26%20AI-Powered%20Content%20Suggestions%20With%20Pinterest%20API.json) |
@@ -418,12 +419,13 @@ This section includes 28 additional n8n integration templates covering a wide ra
 
 ### How do I automate forms and surveys with n8n?
 
-This section contains 3 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, or qualify appointment requests using AI. These templates streamline data collection and lead processing workflows.
+This section contains 4 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, or qualify appointment requests using AI. These templates streamline data collection and lead processing workflows.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
 | Conversational Interviews with AI Agents and n8n Forms | Implements AI-powered conversational interviews using n8n Forms for interactive data collection. | Research/Marketing | [Link to Template](Forms_and_Surveys/Conversational%20Interviews%20with%20AI%20Agents%20and%20n8n%20Forms.json) |
 | Email Subscription Service with n8n Forms, Airtable and AI | Manages email subscriptions with n8n Forms, stores data in Airtable, and uses AI for processing. | Marketing/Communication | [Link to Template](Forms_and_Surveys/Email%20Subscription%20Service%20with%20n8n%20Forms,%20Airtable%20and%20AI.json) |
+| Generate a Song from a Form (Tunova) | A hosted n8n Form collects a text prompt, then Tunova generates an original Suno AI song (v5.5) and returns the audio URL. Core HTTP node — runs on any n8n. Free API key at tunova.ai. | Marketing/Creative | [Link to Template](Forms_and_Surveys/Tunova%20-%20Generate%20a%20song%20from%20a%20form.json) |
 | Qualifying Appointment Requests with AI & n8n Forms | Uses AI to qualify and process appointment requests submitted through n8n Forms. | Sales/Support | [Link to Template](Forms_and_Surveys/Qualifying%20Appointment%20Requests%20with%20AI%20&%20n8n%20Forms.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)


### PR DESCRIPTION
Adds two ready-to-import templates that generate **Suno AI music** via the [Tunova](https://tunova.ai) API.

- **Generate a Song from a Form (Tunova)** → `Forms_and_Surveys/` — a hosted form collects a prompt; returns the finished audio URL.
- **Generate a Song via Webhook (Tunova / Suno API)** → `Other_Integrations_and_Use_Cases/` — POST a prompt, get back the audio URL (drop-in music endpoint).

Both use the **core HTTP Request node** (no community node needed — run on any n8n, Cloud or self-hosted), were validated by `n8n import:workflow`, and contain **no credentials/keys** (placeholder credential refs; users add their own free Tunova key). README tables + section counts updated.