### PR TITLE
Add: Instant Lead Reply - Free Webhook Auto-Responder (Forms & Surveys)

### DIFF
--- a/Forms_and_Surveys/Instant Lead Reply - Free Webhook Auto-Responder.json
+++ b/Forms_and_Surveys/Instant Lead Reply - Free Webhook Auto-Responder.json
@@ -1,0 +1,103 @@
+{
+  "name": "Instant Lead Reply \u2014 Lite (free)",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lead-reply-lite",
+        "responseMode": "responseNode",
+        "options": {
+          "rawBody": false
+        }
+      },
+      "id": "d3e00003-0003-4c01-8001-000000000001",
+      "name": "Lead intake (Webhook)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        -220,
+        300
+      ],
+      "webhookId": "lead-reply-lite-webhook"
+    },
+    {
+      "parameters": {
+        "fromEmail": "{{SENDER_EMAIL}}",
+        "toEmail": "={{ $json.body.email }}",
+        "subject": "We've received your message \u2705",
+        "emailFormat": "html",
+        "html": "=<div style=\"font-family:Arial,Helvetica,sans-serif;font-size:15px;color:#1a1a1a;line-height:1.5\">\n<p>Hi {{ $json.body.name }},</p>\n<p>Thanks for reaching out \u2014 we've received your message and will get back to you shortly, usually within a few business hours.</p>\n<p>Here is a copy of your request:</p>\n<blockquote style=\"border-left:3px solid #ddd;margin:8px 0;padding:4px 12px;color:#555\">{{ $json.body.message }}</blockquote>\n<p>If it's urgent, you can also call us directly at <strong>{{BUSINESS_PHONE}}</strong>.</p>\n<p>Talk soon,<br/><strong>{{BUSINESS_NAME}}</strong></p>\n</div>",
+        "options": {
+          "appendAttribution": false
+        }
+      },
+      "id": "d3e00003-0003-4c01-8001-000000000002",
+      "name": "Instant reply to lead",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        0,
+        300
+      ],
+      "credentials": {
+        "smtp": {
+          "id": "{{SMTP_CREDENTIAL_ID}}",
+          "name": "SMTP"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"status\": \"ok\", \"message\": \"Thanks \u2014 your request has been received. We'll get back to you shortly.\" } }}",
+        "options": {}
+      },
+      "id": "d3e00003-0003-4c01-8001-000000000003",
+      "name": "Respond to form",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        220,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Lead intake (Webhook)": {
+      "main": [
+        [
+          {
+            "node": "Instant reply to lead",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Instant reply to lead": {
+      "main": [
+        [
+          {
+            "node": "Respond to form",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": {
+    "templateId": "instant-lead-reply-lite",
+    "description": "Instant Lead Reply \u2014 Lite (free). Incoming lead (webhook) \u2192 instant acknowledgement email to the lead \u2192 JSON response to the form. Free version of the n8n Lead Capture Kit."
+  },
+  "tags": [
+    {
+      "name": "lead-capture-lite"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ This section includes 29 additional n8n integration templates covering a wide ra
 
 ### How do I automate forms and surveys with n8n?
 
-This section contains 4 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, or qualify appointment requests using AI. These templates streamline data collection and lead processing workflows.
+This section contains 5 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, qualify appointment requests using AI, or instantly acknowledge a website lead via webhook. These templates streamline data collection and lead processing workflows.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -427,6 +427,7 @@ This section contains 4 form and survey automation templates for n8n. Conduct AI
 | Email Subscription Service with n8n Forms, Airtable and AI | Manages email subscriptions with n8n Forms, stores data in Airtable, and uses AI for processing. | Marketing/Communication | [Link to Template](Forms_and_Surveys/Email%20Subscription%20Service%20with%20n8n%20Forms,%20Airtable%20and%20AI.json) |
 | Generate a Song from a Form (Tunova) | A hosted n8n Form collects a text prompt, then Tunova generates an original Suno AI song (v5.5) and returns the audio URL. Core HTTP node — runs on any n8n. Free API key at tunova.ai. | Marketing/Creative | [Link to Template](Forms_and_Surveys/Tunova%20-%20Generate%20a%20song%20from%20a%20form.json) |
 | Qualifying Appointment Requests with AI & n8n Forms | Uses AI to qualify and process appointment requests submitted through n8n Forms. | Sales/Support | [Link to Template](Forms_and_Surveys/Qualifying%20Appointment%20Requests%20with%20AI%20&%20n8n%20Forms.json) |
+| Instant Lead Reply - Free Webhook Auto-Responder | Catches a website contact-form submission via webhook and immediately sends the lead a warm acknowledgement email quoting their own message back. 3 nodes, no branching. Free core of a lead-response kit (Vixelys). | Sales/Support | [Link to Template](Forms_and_Surveys/Instant%20Lead%20Reply%20-%20Free%20Webhook%20Auto-Responder.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 


### PR DESCRIPTION
## Summary

Adds a small 3-node webhook template to the Forms & Surveys category: catches a website contact-form POST and instantly sends the lead a warm acknowledgement email (quotes their own message back, gives a phone number if urgent).

- Webhook → SMTP email reply → JSON response to the form
- No branching, no external services beyond SMTP — tested end-to-end on a clean n8n 2.28.6 instance with real SMTP (Mailpit) before submitting
- It's the free 3-node core of a lead-response kit I sell on Gumroad (Vixelys) — this template on its own is fully functional, no upsell gating inside the JSON itself

## Checklist

- [x] Valid n8n workflow JSON, exported from a real instance
- [x] Meaningful name and description
- [x] Tested and working (n8n 2.28.6)
- [x] No credentials, API keys, or sensitive data — only documented `{{PLACEHOLDER}}` tokens
- [x] File name matches template title
- [x] README.md row added under Forms & Surveys, count updated 4 → 5