### PR TITLE
Add Latchshot binary webpage capture workflow

### DIFF
--- a/Other_Integrations_and_Use_Cases/Latchshot — capture a public webpage.json
+++ b/Other_Integrations_and_Use_Cases/Latchshot — capture a public webpage.json
@@ -1,0 +1,141 @@
+{
+  "id": "LatchshotCapture",
+  "name": "Latchshot — capture a public webpage",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "5ccf21c2-f99b-4f11-9ac2-f71751120649",
+      "name": "Run workflow",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        240
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "1fb79dbb-0813-4d30-9987-d85dcaf69142",
+              "name": "url",
+              "value": "https://example.com",
+              "type": "string"
+            },
+            {
+              "id": "833ef5dc-57ec-4cd8-b092-14ba989ed70d",
+              "name": "width",
+              "value": 1440,
+              "type": "number"
+            },
+            {
+              "id": "0052935e-b186-466b-98e7-024fd6a72dbe",
+              "name": "height",
+              "value": 900,
+              "type": "number"
+            },
+            {
+              "id": "0209741d-e9a4-4576-b540-fbd41106a2a0",
+              "name": "fullPage",
+              "value": false,
+              "type": "boolean"
+            },
+            {
+              "id": "98d81481-ab42-474c-b95a-c392a3e5134b",
+              "name": "delayMs",
+              "value": 250,
+              "type": "number"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "e674a44c-c554-471a-b3fc-e94284bc7f46",
+      "name": "Set capture input",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        240,
+        240
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://latchshot.fly.dev/v1/render",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { url: $json.url, kind: 'screenshot', format: 'png', width: $json.width, height: $json.height, fullPage: $json.fullPage, delayMs: $json.delayMs } }}",
+        "options": {
+          "timeout": 45000,
+          "response": {
+            "response": {
+              "responseFormat": "file",
+              "outputPropertyName": "capture"
+            }
+          }
+        }
+      },
+      "id": "864e3340-6a02-4f0e-93bb-24ab48b99df2",
+      "name": "Capture public page",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        500,
+        240
+      ]
+    },
+    {
+      "parameters": {
+        "content": "### Add the credential before the first run\nOpen **Capture public page**, select or create a **Bearer Auth** credential, and paste only the `ls_live_…` token. The exported workflow contains no API key.\n\nThe successful response is binary field `capture`. Connect it to storage, email, chat, or another file-capable node.",
+        "height": 250,
+        "width": 390
+      },
+      "id": "a35d101a-a644-4e92-a4a4-9de8cf997f18",
+      "name": "Setup note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        380,
+        -80
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Run workflow": {
+      "main": [
+        [
+          {
+            "node": "Set capture input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set capture input": {
+      "main": [
+        [
+          {
+            "node": "Capture public page",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "ff4a967b-6b87-489e-bd8d-bc4c4918e959",
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": []
+}

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Explore 13 social media automation templates for n8n covering Instagram, Twitter
 
 ### What other n8n integration templates are available?
 
-This section includes 29 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
+This section includes 30 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -410,6 +410,7 @@ This section includes 29 additional n8n integration templates covering a wide ra
 | Introduction to the HTTP Tool | Basic tutorial on using HTTP tools in n8n. | Development | [Link to Template](Other_Integrations_and_Use_Cases/Introduction%20to%20the%20HTTP%20Tool.json) |
 | KB Tool - Confluence Knowledge Base | Integrates with Confluence for knowledge base management. | Documentation/IT | [Link to Template](Other_Integrations_and_Use_Cases/KB%20Tool%20-%20Confluence%20Knowledge%20Base.json) |
 | Komos Regulated Browser Ops Task Queue | Queues a [Komos](https://www.komos.ai/) browser automation task from n8n for CRA, banking, or insurance portal operations with audit-ready run metadata. | Ops/Compliance | [Link to Template](Other_Integrations_and_Use_Cases/Komos%20Regulated%20Browser%20Ops%20Task%20Queue.json) |
+| Latchshot — capture a public webpage | Captures a public URL as a binary PNG through Latchshot using an n8n Bearer credential, typed viewport inputs, bounded delay, and no embedded API key. The output is ready for storage, email, chat, or file-aware nodes. | Engineering/Automation | [Link to Template](Other_Integrations_and_Use_Cases/Latchshot%20%E2%80%94%20capture%20a%20public%20webpage.json) |
 | LINE Assistant with Google Calendar and Gmail | Creates a LINE assistant that integrates with Google Calendar and Gmail. | Productivity/Communication | [Link to Template](Other_Integrations_and_Use_Cases/LINE%20Assistant%20with%20Google%20Calendar%20and%20Gmail%20Integration.json) |
 | Monthly Spotify Track Archiving | Archives and classifies monthly Spotify tracks into playlists. | Personal/Music | [Link to Template](Other_Integrations_and_Use_Cases/Monthly%20Spotify%20Track%20Archiving%20and%20Playlist%20Classification.json) |
 | Obsidian Notes Read Aloud | Converts Obsidian notes into audio format as a podcast feed. | Productivity/Content | [Link to Template](Other_Integrations_and_Use_Cases/Obsidian%20Notes%20Read%20Aloud%20using%20AI_%20Available%20as%20a%20Podcast%20Feed.json) |


### PR DESCRIPTION
## Summary

- adds an importable n8n workflow for capturing a public URL as binary PNG data through Latchshot
- keeps the API token in an n8n Bearer credential and out of the workflow JSON
- provides typed, bounded inputs and file output `binary.capture`
- includes setup notes on the canvas

## Testing

- imported successfully into a fresh n8n 2.30.7 image (`sha256:23a26975c21aa6f7113286668b35e2831ec898d3a7fbfa1ac8ff16f1bdf88c37`)
- verified the workflow completed against production and returned a valid 17,883-byte 1440×900 PNG
- verified a missing credential fails closed with `Credentials not found`
- verified the JSON contains no credential object, API key, or sensitive data

## Disclosure

I maintain Latchshot, the API used by this workflow. The integration source is MIT; this repository distributes its collection under CC BY 4.0. Latchshot has a recurring 100-render/month free plan, but this workflow is not an n8n Marketplace listing or endorsement.