### PR TITLE
Add the Latchshot credential handoff

### DIFF
--- a/Other_Integrations_and_Use_Cases/Latchshot — capture a public webpage.json
+++ b/Other_Integrations_and_Use_Cases/Latchshot — capture a public webpage.json
@@ -90,7 +90,7 @@
     },
     {
       "parameters": {
-        "content": "### Add the credential before the first run\nOpen **Capture public page**, select or create a **Bearer Auth** credential, and paste only the `ls_live_…` token. The exported workflow contains no API key.\n\nThe successful response is binary field `capture`. Connect it to storage, email, chat, or another file-capable node.",
+        "content": "### Add the credential before the first run\nGet a recurring Free key at https://latchshot.fly.dev/?intent=n8ncatalog#trial — 100 successful renders each UTC month, no card.\n\nOpen **Capture public page**, select or create a **Bearer Auth** credential, and paste only the `ls_live_…` token. The exported workflow contains no API key.\n\nThe successful response is binary field `capture`. Connect it to storage, email, chat, or another file-capable node.",
         "height": 250,
         "width": 390
       },
@@ -133,7 +133,7 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "ff4a967b-6b87-489e-bd8d-bc4c4918e959",
+  "versionId": "ee32aad4-30a7-4752-9e30-9282573fad24",
   "meta": {
     "templateCredsSetupCompleted": false
   },


### PR DESCRIPTION
## Summary

- follows up on merged PR #158 by giving catalog importers the missing place to obtain the Bearer credential named in the canvas note
- adds the recurring Free-plan URL and exact allowance without embedding a credential
- updates the workflow version ID; the render request, typed bounds, binary output, and secret handling are unchanged

## Verification

- the one changed JSON file parses and contains no API key or credential object
- its 3,877 bytes exactly match the public `v1.0.1` release asset and production copy
- SHA-256: `b1b0b7a5af9f5349dac692589f4cf22f7ea2e67054e24a8b88c574331c52d03f`
- imported successfully into the pinned n8n 2.30.7 image
- the service's exact lowercase `n8ncatalog` attribution is deployed and rejects case variants

## Disclosure

I maintain Latchshot. This is a focused activation fix for the already accepted workflow, not a new template or an n8n Marketplace claim.
