### PR TITLE
Add template: DaoXE multi-model chat with automatic fallback

### DIFF
--- a/OpenAI_and_LLMs/DaoXE Multi-Model Chat with Automatic Fallback.json
+++ b/OpenAI_and_LLMs/DaoXE Multi-Model Chat with Automatic Fallback.json
@@ -1,0 +1,280 @@
+{
+  "name": "DaoXE Multi-Model Chat with Automatic Fallback",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DaoXE multi-model fallback (one API key)\n\n**What it does:** calls a primary model on DaoXE; if that request errors, it automatically retries the same prompt on a fallback model — all through **one** OpenAI-compatible key and **one** Base URL (`https://daoxe.com/v1`).\n\n### Setup (2 minutes)\n1. **Credentials → New → Header Auth** — Name: `Authorization`, Value: `Bearer <YOUR_DAOXE_API_KEY>`. Select it in both HTTP nodes.\n2. Open **Set inputs** and replace `YOUR_DAOXE_MODEL_ID` / `YOUR_DAOXE_FALLBACK_MODEL_ID` with two exact model IDs available to your account (from your DaoXE dashboard or `GET /v1/models` — do not hardcode a list from a blog post).\n3. Click **Test workflow**.\n\nDaoXE is a multi-model, multi-protocol gateway. Not available in mainland China.\nhttps://daoxe.com/?utm_source=n8n&utm_medium=template&utm_campaign=nocode_multimodel",
+        "height": 460,
+        "width": 420,
+        "color": 4
+      },
+      "id": "11111111-0000-4000-8000-000000000001",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -460,
+        -120
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "11111111-0000-4000-8000-000000000002",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a0000000-0000-0000-0000-000000000001",
+              "name": "prompt",
+              "value": "Give me three punchy blog-post titles about honest, no-swapping AI API gateways.",
+              "type": "string"
+            },
+            {
+              "id": "a0000000-0000-0000-0000-000000000002",
+              "name": "system",
+              "value": "You are a concise, helpful assistant. Answer in plain text.",
+              "type": "string"
+            },
+            {
+              "id": "a0000000-0000-0000-0000-000000000003",
+              "name": "primary_model",
+              "value": "YOUR_DAOXE_MODEL_ID",
+              "type": "string"
+            },
+            {
+              "id": "a0000000-0000-0000-0000-000000000004",
+              "name": "fallback_model",
+              "value": "YOUR_DAOXE_FALLBACK_MODEL_ID",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "11111111-0000-4000-8000-000000000003",
+      "name": "Set inputs",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        220,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://daoxe.com/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": {{ JSON.stringify($json.primary_model) }},\n  \"messages\": [\n    { \"role\": \"system\", \"content\": {{ JSON.stringify($json.system) }} },\n    { \"role\": \"user\", \"content\": {{ JSON.stringify($json.prompt) }} }\n  ]\n}",
+        "options": {}
+      },
+      "id": "11111111-0000-4000-8000-000000000004",
+      "name": "Primary model (DaoXE)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        460,
+        120
+      ],
+      "onError": "continueErrorOutput",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "DaoXE (Header Auth)"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://daoxe.com/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": {{ JSON.stringify($('Set inputs').item.json.fallback_model) }},\n  \"messages\": [\n    { \"role\": \"system\", \"content\": {{ JSON.stringify($('Set inputs').item.json.system) }} },\n    { \"role\": \"user\", \"content\": {{ JSON.stringify($('Set inputs').item.json.prompt) }} }\n  ]\n}",
+        "options": {}
+      },
+      "id": "11111111-0000-4000-8000-000000000005",
+      "name": "Fallback model (DaoXE)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        680,
+        300
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "DaoXE (Header Auth)"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "b0000000-0000-0000-0000-000000000001",
+              "name": "answer",
+              "value": "={{ $json.choices[0].message.content }}",
+              "type": "string"
+            },
+            {
+              "id": "b0000000-0000-0000-0000-000000000002",
+              "name": "served_model",
+              "value": "={{ $json.model }}",
+              "type": "string"
+            },
+            {
+              "id": "b0000000-0000-0000-0000-000000000003",
+              "name": "via",
+              "value": "primary",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "11111111-0000-4000-8000-000000000006",
+      "name": "Answer (primary)",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        680,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "c0000000-0000-0000-0000-000000000001",
+              "name": "answer",
+              "value": "={{ $json.choices[0].message.content }}",
+              "type": "string"
+            },
+            {
+              "id": "c0000000-0000-0000-0000-000000000002",
+              "name": "served_model",
+              "value": "={{ $json.model }}",
+              "type": "string"
+            },
+            {
+              "id": "c0000000-0000-0000-0000-000000000003",
+              "name": "via",
+              "value": "fallback",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "11111111-0000-4000-8000-000000000007",
+      "name": "Answer (fallback)",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        900,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Set inputs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set inputs": {
+      "main": [
+        [
+          {
+            "node": "Primary model (DaoXE)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Primary model (DaoXE)": {
+      "main": [
+        [
+          {
+            "node": "Answer (primary)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Fallback model (DaoXE)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fallback model (DaoXE)": {
+      "main": [
+        [
+          {
+            "node": "Answer (fallback)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": [
+    {
+      "name": "DaoXE"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ This is the largest category with 17 AI and LLM templates for n8n. Templates inc
 | SupportFlow Lite - Simple AI Customer Support Chatbot | A lightweight AI chatbot that answers customer questions using company info and OpenAI gpt-4o-mini. Easy single-workflow setup with Google Sheets knowledge base. | Customer Support/AI | [Link to Template](OpenAI_and_LLMs/SupportFlow%20Lite%20-%20Simple%20AI%20Customer%20Support%20Chatbot.json) |
 | GCF Token Optimization for LLM Tool Responses | Fetches GitHub contributors, batches into an array, encodes to GCF (Graph Compact Format) for 53-71% fewer tokens, then decodes back to JSON losslessly. Uses the n8n-nodes-gcf community node. | AI/DevOps/Optimization | [Link to Template](OpenAI_and_LLMs/GCF%20Token%20Optimization%20for%20LLM%20Tool%20Responses.json) |
 | n8n + Local LLM (Ollama) Basic Setup | Connect n8n with local LLMs (Llama 3, Mistral, Phi-3) for 100% free AI automation. No API keys required. | AI/Automation | [Link to Template](./OpenAI_and_LLMs/Ollama_Basic_Workflow.json) |
+| DaoXE Multi-Model Chat with Automatic Fallback | Calls a primary model and, if it errors, automatically retries the same prompt on a fallback model — all through one OpenAI-compatible API key (DaoXE gateway). Pure HTTP nodes, so it runs on any n8n version. | AI/Development | [Link to Template](OpenAI_and_LLMs/DaoXE%20Multi-Model%20Chat%20with%20Automatic%20Fallback.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 


### PR DESCRIPTION
Adds one OpenAI_and_LLMs template: **DaoXE Multi-Model Chat with Automatic Fallback**.

**What it does:** calls a primary model and, on error, automatically retries the same prompt on a fallback model — all through a single OpenAI-compatible API key and Base URL. It uses only core **HTTP Request** nodes (no special AI nodes), so it imports and runs on any recent n8n.

- No credentials or API keys in the file (Header Auth credential + placeholder model IDs; `templateCredsSetupCompleted: false`).
- A Sticky Note documents the ~2-minute setup.
- README row added under the OpenAI, LLMs, and AI agents table.

Disclosure: it points at DaoXE (an OpenAI-compatible gateway) by default, but every value is a normal setting — you can point the same workflow at any OpenAI-compatible endpoint. DaoXE is a service I work on; not available in mainland China.

Made with [Cursor](https://cursor.com)