### PR TITLE
docs(ops): add action failure triage and contribution guardrail rules (#164)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pcoletsos

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report a broken template link, malformed file, or repo behavior issue.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Keep reports concise and reproducible.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Short description of the bug.
+      placeholder: Broken link in README section...
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Where is the problem?
+      description: File path(s), section names, or template names.
+      placeholder: README.md, OpenAI_and_LLMs/...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps for maintainers to reproduce.
+      placeholder: 1. Open... 2. Click... 3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone suggestion
+      description: Use Backlog if unsure.
+      placeholder: Backlog

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Discussion
+    url: https://github.com/pcoletsos/awesome-n8n-templates/discussions
+    about: Use Discussions for open-ended ideas or questions.

--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -1,0 +1,34 @@
+name: Content/category request
+description: Request a new category, rename, or indexing/content improvement.
+title: "content: "
+labels:
+  - enhancement
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Request summary
+      placeholder: Add a new category for CRM automations...
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this useful?
+      description: Briefly describe expected value for contributors/users.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Files/folders likely affected.
+      placeholder: README.md table update + new folder...
+    validations:
+      required: true
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone suggestion
+      description: Use Backlog if unsure.
+      placeholder: Backlog

--- a/.github/ISSUE_TEMPLATE/template_submission.yml
+++ b/.github/ISSUE_TEMPLATE/template_submission.yml
@@ -1,0 +1,44 @@
+name: Template submission
+description: Propose adding a new n8n template to this repository.
+title: "template: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to propose a new template addition.
+  - type: input
+    id: template_name
+    attributes:
+      label: Template name
+      placeholder: AI-powered email triage for Outlook...
+    validations:
+      required: true
+  - type: input
+    id: category
+    attributes:
+      label: Target category folder
+      description: Existing folder preferred.
+      placeholder: Gmail_and_Email_Automation
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Source and attribution
+      description: Provide original source URL and attribution details.
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What does this template do?
+    validations:
+      required: true
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone suggestion
+      description: Use Backlog if unsure.
+      placeholder: Backlog

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Copilot Instructions
+
+Follow `CONTRIBUTING.md` for workflow and branch conventions.
+
+Repository profile:
+- lightweight content/fork repo
+- avoid heavyweight CI/policy proposals by default
+- preserve current folder/category layout unless change is intentional
+
+Before non-trivial edits:
+1. ensure a linked GitHub issue exists
+2. ensure the issue has a milestone (`Backlog` fallback)
+3. work on a branch, not directly on `main`
+
+GitHub is the live source of truth for issues, milestones, PRs, and checks.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed and why? Keep this concise. -->
+
+## Linked Issue
+
+<!-- Use one of: Closes #<id> or Refs #<id> -->
+
+## Validation
+
+- [ ] Ran `python .github/scripts/validate_contribution_guardrails.py`
+- [ ] Verified changed files/paths are intentional
+- [ ] Kept changes lightweight and repo-appropriate
+
+## Change Type
+
+- [ ] Template content update
+- [ ] README/docs update
+- [ ] Repo workflow/guardrail update
+- [ ] Other
+
+## Notes
+
+<!-- Optional: mention file moves, follow-up work, or tradeoffs -->

--- a/.github/scripts/validate_contribution_guardrails.py
+++ b/.github/scripts/validate_contribution_guardrails.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Lightweight repository contribution guardrail checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures: list[str] = []
+
+    required_files = [
+        "CONTRIBUTING.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+        ".github/copilot-instructions.md",
+        ".github/pull_request_template.md",
+        ".github/CODEOWNERS",
+        ".github/ISSUE_TEMPLATE/config.yml",
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ".github/ISSUE_TEMPLATE/template_submission.yml",
+        ".github/ISSUE_TEMPLATE/content_request.yml",
+        ".github/workflows/contribution-guardrails.yml",
+    ]
+
+    for rel_path in required_files:
+        if not (repo_root / rel_path).exists():
+            failures.append(f"Missing required file: {rel_path}")
+
+    def read_text(rel_path: str) -> str:
+        path = repo_root / rel_path
+        if not path.exists():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    contributing = read_text("CONTRIBUTING.md")
+    if "GitHub as the live source of truth" not in contributing:
+        failures.append("CONTRIBUTING.md must declare GitHub as the live source of truth.")
+    if "<actor>/<type>/<scope>/<task>-<id>" not in contributing:
+        failures.append("CONTRIBUTING.md must define canonical branch naming format.")
+    if "Backlog" not in contributing:
+        failures.append("CONTRIBUTING.md must mention Backlog milestone fallback.")
+
+    readme = read_text("README.md")
+    if "GitHub is the live source of truth" not in readme:
+        failures.append("README.md must include source-of-truth language.")
+
+    pr_template = read_text(".github/pull_request_template.md")
+    if "Linked Issue" not in pr_template:
+        failures.append("PR template must include a linked issue section.")
+    if "validate_contribution_guardrails.py" not in pr_template:
+        failures.append("PR template must include local guardrail validation checkbox.")
+
+    codeowners = read_text(".github/CODEOWNERS").strip()
+    if not codeowners:
+        failures.append(".github/CODEOWNERS cannot be empty.")
+
+    issue_form_paths = [
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ".github/ISSUE_TEMPLATE/template_submission.yml",
+        ".github/ISSUE_TEMPLATE/content_request.yml",
+    ]
+    for rel_path in issue_form_paths:
+        content = read_text(rel_path)
+        if "Backlog" not in content:
+            failures.append(f"{rel_path} must reference Backlog milestone usage.")
+
+    if failures:
+        print("Contribution guardrail validation failed:\n")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Contribution guardrail validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/contribution-guardrails.yml
+++ b/.github/workflows/contribution-guardrails.yml
@@ -1,0 +1,29 @@
+name: Contribution Guardrails
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  validate-contribution-guardrails:
+    name: Validate Contribution Guardrails
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run lightweight guardrail checks
+        run: python .github/scripts/validate_contribution_guardrails.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,8 @@ Use `CONTRIBUTING.md` as the canonical workflow contract.
 ## Source Of Truth
 
 GitHub is the live source of truth for issue state, milestones, PR status, and checks.
+
+## CI Action Failure & Guardrail Rules
+
+- On any CI/Action failure, extract logs via `gh run view <run_id> --log-failed`, identify root cause, and implement pre-flight prevention.
+- Run `python3 .github/scripts/validate_contribution_guardrails.py` locally to verify PR metadata prior to pushing branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS
+
+Use `CONTRIBUTING.md` as the canonical workflow contract.
+
+## Repo Profile
+
+- Type: lightweight content/fork repository
+- Primary artifacts: n8n template JSON files and indexing docs
+- Policy posture: minimal process, practical guardrails
+
+## Required Flow
+
+1. Work from a branch (never directly on `main` for non-trivial tasks).
+2. Tie non-trivial work to a GitHub issue with a milestone.
+3. Use `Backlog` when no thematic milestone applies.
+4. Keep CI and policy additions lightweight.
+
+## Source Of Truth
+
+GitHub is the live source of truth for issue state, milestones, PR status, and checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE
+
+Follow `CONTRIBUTING.md` for canonical contribution workflow.
+
+Lightweight repo rules:
+- favor minimal, practical process
+- keep checks fast
+- route non-trivial work through issue + milestone + branch
+- default milestone to `Backlog` when needed
+
+GitHub state is authoritative over markdown snapshots.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# CONTRIBUTING
+
+Thanks for helping improve this repository of n8n templates.
+
+This is a lightweight content repo. Keep process and automation practical:
+- prefer small, focused pull requests
+- avoid introducing heavy CI or policy overhead
+- preserve upstream usability for template contributors
+
+## Canonical Workflow
+
+Use GitHub as the live source of truth for:
+- issues and milestones
+- pull requests and review state
+- workflow/check run status
+- releases
+
+If markdown notes and GitHub disagree, GitHub wins.
+
+For non-trivial changes:
+1. Find an existing issue or open a new one.
+2. Ensure the issue has a milestone.
+3. Use `Backlog` when no thematic milestone fits.
+4. Create a branch before editing.
+
+Canonical branch format:
+
+```text
+<actor>/<type>/<scope>/<task>-<id>
+```
+
+Examples:
+- `codex/chore/shared/lightweight-repo-contribution-workflow-1`
+- `user/docs/readme/add-telegram-links-42`
+
+## Shorthand Prompts
+
+- `start <task>`: issue + milestone + branch, then begin work
+- `record it`: commit current changes
+- `publish it`: push current branch
+- `propose it`: open or update the PR
+- `land it`: squash-merge the PR after checks + approval
+- `ship it`: commit + push + PR
+- `finish it`: commit + push + PR + merge
+- `finish it for #<id>`: full-flow shorthand tied to an issue
+
+## Scope Guardrails
+
+- This repo mainly stores templates and metadata content.
+- Keep CI checks lightweight and fast.
+- Do not add heavyweight test matrices or strict gating unless clearly necessary.
+- Keep naming and category changes consistent with existing structure.
+
+## PR Expectations
+
+Every PR should include:
+- linked issue (`Closes #...` or `Refs #...`)
+- short summary of what changed
+- quick validation notes (what was checked locally)
+- note if any files were moved/renamed
+
+## Local Validation
+
+Run lightweight checks before opening a PR:
+
+```bash
+python .github/scripts/validate_contribution_guardrails.py
+```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,11 @@
+# GEMINI
+
+Read and follow `CONTRIBUTING.md` first.
+
+For non-trivial changes:
+1. Reuse/create a GitHub issue.
+2. Ensure a milestone is assigned (`Backlog` if no fit).
+3. Create a branch before editing.
+
+Keep process and CI lightweight for this content-focused repository.
+GitHub is the live source of truth.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,3 +9,8 @@ For non-trivial changes:
 
 Keep process and CI lightweight for this content-focused repository.
 GitHub is the live source of truth.
+
+## CI Action Failure & Guardrail Rules
+
+- On any CI/Action failure, extract logs via `gh run view <run_id> --log-failed`, identify root cause, and implement pre-flight prevention.
+- Run `python3 .github/scripts/validate_contribution_guardrails.py` locally to verify PR metadata prior to pushing branches.

--- a/README-zh.md
+++ b/README-zh.md
@@ -311,7 +311,8 @@
 
 ---
 
-如果您想贡献其他模板或建议新类别，请随时提出issue或pull request！
+如果您想贡献其他模板或建议新类别，请在 GitHub 上提交 issue 或 pull request。
+GitHub 是 issues、milestones、pull requests 和检查状态的实时事实来源。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ All automation templates in this repository were found online and are uploaded h
 
 ---
 
-If you would like to contribute additional templates or suggest new categories, feel free to open an issue or pull request!
+If you would like to contribute additional templates or suggest new categories, open an issue or pull request on GitHub.
+GitHub is the live source of truth for issues, milestones, pull requests, and check status.
 
 ---
 


### PR DESCRIPTION
## Linked issue

Linked issue: Fixes #164

## Summary

Adds mandatory agent instructions in `AGENTS.md` and `GEMINI.md` for automated CI failure triage (`gh run view <run_id> --log-failed`) and pre-flight guardrail validation.

## Affected scope

- [ ] cluster
- [ ] services
- [x] ops
- [x] docs

## Pre-flight & local validation

- [x] Contribution guardrails
- [x] Manifest validation
- [ ] Kustomize validation
- [ ] Existing infra validation
- [ ] Not run (reason described below)

## Documentation impact

- [ ] No docs changes required
- [x] Docs updated in this PR
- [ ] Docs follow-up issue linked below

## Risk & Rollback

- [x] Not risky / no rollback needed
- [ ] Rollback plan included below