### PR TITLE
Add disk space watchdog template (devops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,13 @@ Find 5 database and storage automation templates for n8n. Chat with PostgreSQL u
 
 ### What n8n templates are available for DevOps and server automation?
 
-This section includes 2 DevOps and server automation templates for n8n. Trigger Linux system updates via authenticated webhooks over SSH, or control Docker Compose services remotely through HTTP POST requests. Both templates use SSH for secure server management.
+This section includes 3 DevOps and server automation templates for n8n. Trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely through HTTP POST requests, or watch disk usage across all mountpoints and get alerted before a full disk takes services down. All templates use SSH for secure server management.
 
 | Title | Description | Link |
 |-------|-------------|------|
 | Linux System Update via Webhook | Trigger update & upgrade of your Debian-based server via an authenticated POST request and SSH. | SSH Tools | [Link to Template](devops/linux-update-via-webhook.json)
 | Docker Compose Controller via Webhook | Start or stop Docker Compose services on your server via authenticated HTTP POST request with n8n + SSH. | SSH Tools | [Link to Template](devops/docker-compose-controller.json) |
+| Disk Space Watchdog with Tiered Thresholds | Check disk usage over SSH on a schedule, warn at 80% and 90%, and alert only when a mountpoint changes level - no repeated alerts for the same full disk. Telegram with e-mail fallback. | SSH Tools | [Link to Template](devops/disk-space-watchdog.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 

--- a/devops/disk-space-watchdog.json
+++ b/devops/disk-space-watchdog.json
@@ -1,0 +1,185 @@
+{
+  "name": "Disk space watchdog with tiered thresholds and Telegram alert",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 30
+            }
+          ]
+        }
+      },
+      "id": "f2b10000-0000-4000-8000-000000000001",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "command",
+        "command": "df -P"
+      },
+      "id": "f2b10000-0000-4000-8000-000000000002",
+      "name": "Check Disk Usage (SSH)",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parses the output of \"df -P\", compares it against tiered thresholds (WARN/CRIT)\n// and only reports when a mountpoint CHANGES level. The de-duplication uses n8n's\n// workflow static data, so a disk sitting at 85% for a week alerts once, not 336 times.\n// Thresholds are read from environment variables so the workflow needs no editing.\nconst warnPct = parseInt($env.DISK_WARN_PCT || '80', 10);\nconst critPct = parseInt($env.DISK_CRIT_PCT || '90', 10);\n\nconst raw = $input.first().json.stdout || '';\nconst lines = raw.trim().split('\\n').slice(1);\n\nconst staticData = $getWorkflowStaticData('node');\nif (!staticData.lastLevel) staticData.lastLevel = {};\n\nconst alerts = [];\nfor (const line of lines) {\n  const parts = line.trim().split(/\\s+/);\n  if (parts.length < 6) continue;\n  const filesystem = parts[0];\n  const capacityStr = parts[parts.length - 2];\n  const mount = parts[parts.length - 1];\n  const usedPct = parseInt(capacityStr.replace('%', ''), 10);\n  if (Number.isNaN(usedPct)) continue;\n\n  let level = 'ok';\n  if (usedPct >= critPct) level = 'critical';\n  else if (usedPct >= warnPct) level = 'warning';\n\n  const prevLevel = staticData.lastLevel[mount] || 'ok';\n  if (level !== prevLevel) {\n    staticData.lastLevel[mount] = level;\n    const availGB = (parseInt(parts[parts.length - 3], 10) / 1024 / 1024).toFixed(1);\n    if (level !== 'ok') {\n      alerts.push({ mount, filesystem, usedPct, level, availGB });\n    } else {\n      // Recovery is reported too, so a silent channel means \"nothing changed\",\n      // not \"the workflow died\".\n      alerts.push({ mount, filesystem, usedPct, level, availGB, recovered: true });\n    }\n  }\n}\n\nconst hasAlerts = alerts.length > 0;\nlet message = null;\nif (hasAlerts) {\n  message = alerts.map(a => a.recovered\n    ? `[OK] ${a.mount} back below threshold (${a.usedPct}%)`\n    : `${a.level === 'critical' ? '[CRITICAL]' : '[WARNING]'} ${a.mount} (${a.filesystem}): ${a.usedPct}% used, ${a.availGB} GB free`\n  ).join('\\n');\n}\n\nreturn [{ json: { hasAlerts, message, alerts } }];"
+      },
+      "id": "f2b10000-0000-4000-8000-000000000003",
+      "name": "Parse & Evaluate",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        440,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond1",
+              "leftValue": "={{$json.hasAlerts}}",
+              "rightValue": "",
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "f2b10000-0000-4000-8000-000000000004",
+      "name": "Any alerts?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        660,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "chatId": "={{$env.TG_CHAT_ID}}",
+        "text": "={{$json.message}}",
+        "additionalFields": {}
+      },
+      "id": "f2b10000-0000-4000-8000-000000000005",
+      "name": "Send Telegram Alert",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "onError": "continueErrorOutput",
+      "position": [
+        880,
+        -80
+      ],
+      "credentials": {
+        "telegramApi": {
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "fromEmail": "={{$env.SMTP_FROM}}",
+        "toEmail": "={{$env.SMTP_TO}}",
+        "subject": "Disk space watchdog alert",
+        "text": "={{$json.message}}"
+      },
+      "id": "f2b10000-0000-4000-8000-000000000006",
+      "name": "Send Email Fallback",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        1100,
+        -80
+      ],
+      "credentials": {
+        "smtp": {
+          "name": "SMTP account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Check Disk Usage (SSH)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Disk Usage (SSH)": {
+      "main": [
+        [
+          {
+            "node": "Parse & Evaluate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse & Evaluate": {
+      "main": [
+        [
+          {
+            "node": "Any alerts?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Telegram Alert": {
+      "main": [
+        [],
+        [
+          {
+            "node": "Send Email Fallback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Any alerts?": {
+      "main": [
+        [
+          {
+            "node": "Send Telegram Alert",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds one template to the devops category, following CONTRIBUTING.md.

What it does: runs "df -P" over SSH on a schedule, compares every mountpoint against two thresholds (80% warning / 90% critical by default, both configurable through environment variables) and sends a Telegram message with an e-mail fallback.

Why it is not just another disk alert: it only fires when a mountpoint CHANGES level, using n8n workflow static data to remember the previous state. A disk sitting at 85% for a week alerts once instead of every 30 minutes. Recovery back below the threshold is reported as well, so a quiet channel means "nothing changed" rather than "the workflow died".

Checklist against CONTRIBUTING.md:

Folder: placed in the existing devops/ folder, file name following that folder's kebab-case convention (docker-compose-controller.json, linux-update-via-webhook.json).
README: devops table updated with title, description, department and relative link; the section intro count corrected from 2 to 3 templates.
Secrets: none. Telegram chat ID, SMTP sender and recipient and both thresholds are read from environment variables.
Nodes: valid n8n export using core nodes only (Schedule Trigger, SSH, Code, IF, Telegram, Send Email).
Scope: one template in this pull request.

Written and run by me on my own self-hosted setup. Happy to adjust naming or placement if you would rather have it elsewhere.