### PR TITLE
Add n8n failed execution doctor template

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,14 @@ Find 5 database and storage automation templates for n8n. Chat with PostgreSQL u
 
 ### What n8n templates are available for DevOps and server automation?
 
-This section includes 3 DevOps and server automation templates for n8n. Trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely through HTTP POST requests, or watch disk usage across all mountpoints and get alerted before a full disk takes services down. All templates use SSH for secure server management.
+This section includes 4 DevOps and reliability templates for n8n. Trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely, watch disk usage across mountpoints, or diagnose failed n8n execution JSON without connecting to a live instance.
 
-| Title | Description | Link |
-|-------|-------------|------|
+| Title | Description | Department | Link |
+|-------|-------------|------------|------|
 | Linux System Update via Webhook | Trigger update & upgrade of your Debian-based server via an authenticated POST request and SSH. | SSH Tools | [Link to Template](devops/linux-update-via-webhook.json)
 | Docker Compose Controller via Webhook | Start or stop Docker Compose services on your server via authenticated HTTP POST request with n8n + SSH. | SSH Tools | [Link to Template](devops/docker-compose-controller.json) |
 | Disk Space Watchdog with Tiered Thresholds | Check disk usage over SSH on a schedule, warn at 80% and 90%, and alert only when a mountpoint changes level - no repeated alerts for the same full disk. Telegram with e-mail fallback. | SSH Tools | [Link to Template](devops/disk-space-watchdog.json) |
+| n8n Failed Execution Doctor | Diagnose exported failed n8n execution data locally, identify the failing node, classify common root causes such as 401/403, 429, timeouts, network, invalid input, and expression errors, and return a focused next diagnostic step. No external API key or LLM required. | Engineering | [Link to Template](devops/n8n-failed-execution-doctor.json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 

--- a/devops/n8n-failed-execution-doctor.json
+++ b/devops/n8n-failed-execution-doctor.json
@@ -1,0 +1,51 @@
+{
+  "name": "n8n Failed Execution Doctor",
+  "nodes": [
+    {
+      "parameters": {
+        "inputSource": "passthrough"
+      },
+      "id": "df873507-97e1-4e2a-871a-b48fe4d72212",
+      "name": "When Executed by Another Workflow",
+      "type": "n8n-nodes-base.executeWorkflowTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        -260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst workflow = input.workflow;\nconst execution = input.execution;\n\nif (!workflow || !Array.isArray(workflow.nodes)) {\n  throw new Error('workflow.nodes must be an array');\n}\nif (!execution || typeof execution !== 'object') {\n  throw new Error('execution must be an object');\n}\n\nconst nodeTypes = new Map(\n  workflow.nodes.map((node) => [String(node.name || ''), String(node.type || '')]),\n);\nconst data = execution.data && typeof execution.data === 'object' ? execution.data : {};\nconst result = data.resultData && typeof data.resultData === 'object'\n  ? data.resultData\n  : (execution.resultData && typeof execution.resultData === 'object' ? execution.resultData : {});\nconst lastNode = result.lastNodeExecuted ? String(result.lastNodeExecuted) : null;\nconst runData = result.runData && typeof result.runData === 'object' ? result.runData : {};\nconst failures = [];\nfunction safeMessage(value) {\n  let text = String(value ?? '').replace(/\\s+/g, ' ').trim();\n  text = text.replace(/(api[_-]?key|token|secret|password|authorization)\\s*[:=]\\s*[^\\s,;}]+/gi, '$1=[REDACTED]');\n  text = text.replace(/bearer\\s+[A-Za-z0-9._~+/-]{8,}/gi, 'Bearer [REDACTED]');\n  return text.slice(0, 300);\n}\n\nfunction classify(message, status) {\n  const text = `${String(status ?? '')} ${message}`.toLowerCase();\n  if (['401', '403', 'unauthorized', 'forbidden', 'credential', 'authentication'].some((x) => text.includes(x))) {\n    return ['authentication', 'Verify credential reference, auth scheme, token scope and expiry; then retest only the failing node.'];\n  }\n  if (['429', 'rate limit', 'too many requests'].some((x) => text.includes(x))) {\n    return ['rate_limit', 'Add bounded retry with exponential backoff and respect Retry-After or the upstream rate-limit policy.'];\n  }\n  if (['timeout', 'timed out', 'etimedout', 'econnaborted'].some((x) => text.includes(x))) {\n    return ['timeout', 'Set an explicit timeout, retry only idempotent work, and isolate the slow external call from the main path.'];\n  }\n  if (['econn', 'dns', 'network', 'connection refused', 'socket hang up'].some((x) => text.includes(x))) {\n    return ['network', 'Check endpoint reachability, DNS and TLS first; then add bounded retries and an explicit failure path.'];\n  }\n  if (['400', '422', 'invalid', 'validation', 'bad request'].some((x) => text.includes(x))) {\n    return ['invalid_input', 'Inspect the outbound payload/schema and validate required fields before the failing node.'];\n  }\n  if (['expression', 'undefined', 'cannot read', 'not defined', 'item linking'].some((x) => text.includes(x))) {\n    return ['expression', 'Validate referenced fields, item linking and optional values before evaluating the expression.'];\n  }\n  return ['execution_error', 'Reproduce the failing node with the same sanitized input, then add an explicit error path before re-enabling automation.'];\n}\n\nfunction addFailure(node, rawError) {\n  const error = rawError && typeof rawError === 'object' ? rawError : {};\n  const rawMessage = error.message || error.description || error.name || rawError || 'Execution failed';\n  const statusCode = error.httpCode ?? error.statusCode ?? error.status ?? null;\n  const message = safeMessage(rawMessage);\n  const [category, recommendedNextStep] = classify(message, statusCode);\n  failures.push({\n    node,\n    nodeType: node ? (nodeTypes.get(String(node)) || null) : null,\n    category,\n    statusCode,\n    message,\n    recommendedNextStep,\n  });\n}\nfor (const [nodeName, runs] of Object.entries(runData)) {\n  if (!Array.isArray(runs)) continue;\n  for (const run of runs) {\n    if (!run || typeof run !== 'object' || !run.error) continue;\n    addFailure(nodeName, run.error);\n  }\n}\nif (result.error && failures.length === 0) {\n  addFailure(lastNode, result.error);\n}\n\nconst counts = {};\nfor (const failure of failures) {\n  counts[failure.category] = (counts[failure.category] || 0) + 1;\n}\nconst primaryCategory = Object.entries(counts)\n  .sort((a, b) => b[1] - a[1])[0]?.[0] || 'unknown';\n\nreturn [{ json: {\n  workflowName: String(workflow.name || ''),\n  lastNodeExecuted: lastNode,\n  failureCount: failures.length,\n  primaryCategory,\n  failures,\n  diagnosticStatus: failures.length ? 'FAILED_EXECUTION_ANALYZED' : 'NO_STRUCTURED_ERROR_FOUND',\n  privacyNote: 'Common secret-like strings are redacted and error messages are truncated.',\n} }];\n"
+      },
+      "id": "4aa207b4-a12c-482e-8313-32ad43dd7680",
+      "name": "Diagnose Failed Execution",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        0,
+        0
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When Executed by Another Workflow": {
+      "main": [
+        [
+          {
+            "node": "Diagnose Failed Execution",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "id": "44b9dc86-702b-45e8-9b71-803799778a26",
+  "versionId": "ca9abd80-9bb7-4c14-83e5-00c53828ada5"
+}


### PR DESCRIPTION
## Summary

Adds a small DevOps/reliability workflow that diagnoses exported failed n8n executions without connecting to a live n8n instance.

It identifies the failing/last node, normalizes common failure classes (authentication, rate limit, timeout, network, invalid input, expression errors), sanitizes the returned error text, and provides a focused next diagnostic step.

## Validation

- Valid n8n workflow JSON
- Imports successfully into an isolated n8n 2.33.7 runtime
- Uses only core `Execute Workflow Trigger` and `Code` nodes
- No external API key or LLM required
- Secret scan: no credentials, API keys, email addresses, private keys, or IP addresses
- Workflow is inactive by default

Also updates the DevOps section count and fixes its table header to match the existing four-column rows.