### PR TITLE
Add free YouTube Transcript to Executive Summary n8n workflow template

### DIFF
--- a/OpenAI_and_LLMs/YouTube Transcript to Executive Summary (Free).json
+++ b/OpenAI_and_LLMs/YouTube Transcript to Executive Summary (Free).json
@@ -1,0 +1,188 @@
+{
+  "name": "YouTube Transcript → Executive Summary (Free)",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "yt-transcript-lite",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        250,
+        300
+      ],
+      "webhookId": "yt-transcript-lite"
+    },
+    {
+      "parameters": {
+        "jsCode": "const url = $input.first().json.body.url;\n// Extract video ID from various YouTube URL formats\nlet videoId = null;\nconst patterns = [\n  /(?:youtube\\.com\\/watch\\?v=|youtu\\.be\\/|youtube\\.com\\/embed\\/|youtube\\.com\\/v\\/)([a-zA-Z0-9_-]{11})/,\n  /^([a-zA-Z0-9_-]{11})$/\n];\nfor (const pattern of patterns) {\n  const match = url.match(pattern);\n  if (match) {\n    videoId = match[1];\n    break;\n  }\n}\nif (!videoId) {\n  throw new Error('Invalid YouTube URL. Could not extract video ID.');\n}\nreturn { videoId, url };"
+      },
+      "id": "extract-id",
+      "name": "Extract Video ID",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        450,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================================\n// Fetch Transcript with automatic fallback (v9)\n// Primary:   youtubetranscript.com (free, keyless — same as paid)\n// Fallback:  local bridge using youtube-transcript-api (optional)\n// ============================================================\nconst videoId = $json.videoId;\n// Optional secondary source. Leave empty to disable.\n// Point at any transcript API you have (e.g. a local bridge or\n// transcriptapi.com with your key). Primary source is free & keyless.\nconst FALLBACK_URL = '';\n\nlet raw = null;\nlet source = 'youtubetranscript.com';\n\n// 1) Primary source (free, no API key)\ntry {\n  const resp = await this.helpers.httpRequest({\n    method: 'GET',\n    url: `https://youtubetranscript.com/?server_vid2=${videoId}`,\n    responseFormat: 'text',\n    timeout: 20000,\n  });\n  const isBlocked = /currently blocking us|working on a fix|can't fetch|unable to fetch/i.test(resp) && resp.length < 400;\n  if (!isBlocked && resp.includes('<text')) {\n    raw = resp;\n  }\n} catch (e) {\n  // primary unavailable -> try fallback\n}\n\n// 2) Fallback source (local bridge / any configured transcript API)\nif (!raw && FALLBACK_URL) {\n  try {\n    const fb = await this.helpers.httpRequest({\n      method: 'GET',\n      url: `${FALLBACK_URL}?video_id=${videoId}`,\n      json: true,\n      timeout: 30000,\n    });\n    if (fb && fb.ok && fb.transcript) {\n      raw = fb.transcript;\n      source = 'local-bridge';\n    }\n  } catch (e) {\n    // fallback unavailable\n  }\n}\n\nif (!raw) {\n  throw new Error('Could not fetch a transcript for this video. The free transcript service is temporarily blocked by YouTube — try a video with captions, or try again later.');\n}\n\n// Parse: XML <text> tags (primary) or plain text (fallback)\nlet transcript = '';\nconst textMatches = raw.match(/<text[^>]*>([\\s\\S]*?)<\\/text>/g) || [];\nif (textMatches.length) {\n  transcript = textMatches\n    .map(t => t.replace(/<[^>]+>/g, '').trim())\n    .filter(t => t.length > 0)\n    .join(' ');\n} else {\n  transcript = raw\n    .split('\\n')\n    .filter(l => l.trim() && !l.includes('[') && !l.includes('((') && l.length > 5)\n    .join(' ');\n}\ntranscript = transcript.trim();\nif (!transcript) {\n  throw new Error('Could not extract a transcript for this video. It may have no captions, or the transcript service is unavailable.');\n}\n\nreturn {\n  transcript: transcript.substring(0, 25000),\n  wordCount: transcript.split(' ').length,\n  source,\n};"
+      },
+      "id": "fetch-transcript",
+      "name": "Fetch Transcript",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        650,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "chat",
+        "operation": "complete",
+        "chatModel": "gpt-4o-mini",
+        "messages": {
+          "messages": [
+            {
+              "role": "system",
+              "content": "You are a YouTube content analyst. Analyze the provided transcript and produce an **Executive Summary** (3-5 paragraphs) that captures the key points, insights, and main message of the video. Return as structured JSON with key: summary"
+            },
+            {
+              "role": "user",
+              "content": "={{ $json.transcript }}"
+            }
+          ]
+        },
+        "simplifyOutput": true,
+        "options": {
+          "temperature": 0.3,
+          "maxTokens": 1000
+        }
+      },
+      "id": "ai-analysis",
+      "name": "AI Analysis",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 2,
+      "position": [
+        850,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// OpenAI node (simplifyOutput: true) returns { message: { role, content } }\n// The model is instructed to return JSON with key \"summary\".\nconst msg = $input.first().json.message;\nconst content = (msg && msg.content) || '';\nlet summary = content.trim();\ntry {\n  const parsed = JSON.parse(content);\n  if (parsed && parsed.summary) {\n    summary = parsed.summary;\n  }\n} catch (e) {\n  // content was plain text\n}\n\nconst prev = $('Fetch Transcript').first().json;\nreturn {\n  videoUrl: $('Extract Video ID').first().json.url || '',\n  videoId: $('Extract Video ID').first().json.videoId || '',\n  wordCount: prev.wordCount || 0,\n  summary,\n};"
+      },
+      "id": "format-output",
+      "name": "Format Output",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1050,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "options": {
+          "response": {
+            "responseCode": 200,
+            "respondMode": "allJson",
+            "responseHeaders": {
+              "entries": [
+                {
+                  "name": "Content-Type",
+                  "value": "application/json"
+                }
+              ]
+            }
+          }
+        },
+        "jsCode": "const output = $input.first().json;\nreturn output;"
+      },
+      "id": "respond",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Extract Video ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Video ID": {
+      "main": [
+        [
+          {
+            "node": "Fetch Transcript",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Transcript": {
+      "main": [
+        [
+          {
+            "node": "AI Analysis",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "AI Analysis": {
+      "main": [
+        [
+          {
+            "node": "Format Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Output": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    "youtube",
+    "transcript",
+    "summary",
+    "openai",
+    "content-creation"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ This is the largest category with 17 AI and LLM templates for n8n. Templates inc
 | GCF Token Optimization for LLM Tool Responses | Fetches GitHub contributors, batches into an array, encodes to GCF (Graph Compact Format) for 53-71% fewer tokens, then decodes back to JSON losslessly. Uses the n8n-nodes-gcf community node. | AI/DevOps/Optimization | [Link to Template](OpenAI_and_LLMs/GCF%20Token%20Optimization%20for%20LLM%20Tool%20Responses.json) |
 | n8n + Local LLM (Ollama) Basic Setup | Connect n8n with local LLMs (Llama 3, Mistral, Phi-3) for 100% free AI automation. No API keys required. | AI/Automation | [Link to Template](./OpenAI_and_LLMs/Ollama_Basic_Workflow.json) |
 | DaoXE Multi-Model Chat with Automatic Fallback | Calls a primary model and, if it errors, automatically retries the same prompt on a fallback model — all through one OpenAI-compatible API key (DaoXE gateway). Pure HTTP nodes, so it runs on any n8n version. | AI/Development | [Link to Template](OpenAI_and_LLMs/DaoXE%20Multi-Model%20Chat%20with%20Automatic%20Fallback.json) |
+| YouTube Transcript to Executive Summary (Free) | Fetches a YouTube video transcript and generates a clean 3-5 paragraph executive summary using OpenAI GPT-4o-mini. Webhook-triggered, returns JSON with summary. | Content Creation/AI/Productivity | [Link to Template](OpenAI_and_LLMs/YouTube%20Transcript%20to%20Executive%20Summary%20(Free).json) |
 
 > 🚀 **Automate any workflow.** [Create your free n8n account and start building →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 


### PR DESCRIPTION
## What this adds

A free, ready-to-import n8n workflow: **YouTube Transcript → Executive Summary**.

### How it works
1. **Webhook** receives a POST request with a YouTube URL
2. **Fetch Transcript** extracts the transcript (handles private/unavailable videos)
3. **OpenAI Summarization** sends transcript to GPT-4o-mini for a 3-5 paragraph executive summary
4. **Response** returns JSON with video URL, video ID, word count, and summary

### Why useful
- Quick video comprehension without watching the entire video
- Content research and note-taking
- Video summaries for newsletters or reports

### Details
- Valid n8n workflow JSON (6 nodes, tested)
- No credentials/API keys embedded (uses YOUR_OPENAI_API_KEY placeholder convention)
- Category: `OpenAI_and_LLMs/`
- README table row added

This is the free lite version — the paid version (6 output formats: executive summary, SEO blog draft, X thread, LinkedIn post, takeaways, keywords) is available at [tsnlabs.gumroad.com/l/snmil](https://tsnlabs.gumroad.com/l/snmil).
