### PR TITLE
Add template: Post New Live Tennis Matches to Discord on a Schedule

### DIFF
--- a/Discord/Post New Live Tennis Matches to Discord on a Schedule.json
+++ b/Discord/Post New Live Tennis Matches to Discord on a Schedule.json
@@ -1,0 +1,167 @@
+{
+  "nodes": [
+    {
+      "id": "a1f2c3d4-0001-4a1b-8c2d-100000000001",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [
+        440,
+        40
+      ],
+      "parameters": {
+        "width": 520,
+        "height": 520,
+        "content": "## Post new live tennis matches to Discord\n\n### What it does\n- Every 5 minutes, fetches the currently live tennis matches from the Live Tennis API (`GET /matches?status=live`).\n- Splits the response into one item per match.\n- **Remove Duplicates** (seen in previous executions) keeps only matches that are newly live, so each match is announced **once**.\n- Posts a short message to a Discord channel via an Incoming Webhook.\n\n### Setup (~5 min)\n1. Get a free API key (live scores, no card): https://livetennisapi.com/subscribe/free\n2. In the **HTTP Request** node, create a **Header Auth** credential:\n   - Name: `X-API-Key`\n   - Value: your API key\n3. In the **Discord** node, add a **Discord Webhook** credential (a Discord channel Incoming Webhook URL).\n4. Activate the workflow.\n\nBase URL: `https://api.livetennisapi.com/api/public/v1`. Free tier = 30 req/min, 100 req/day, so a 5-minute schedule stays well within limits. Prefer a dedicated node? Swap the HTTP Request for the community node `n8n-nodes-livetennisapi`.\n\n_Disclosure: this template is contributed by the team behind the Live Tennis API — judge it on the merits._"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "a1f2c3d4-0002-4a1b-8c2d-100000000002",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "position": [
+        1020,
+        280
+      ],
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 5
+            }
+          ]
+        }
+      },
+      "typeVersion": 1.2
+    },
+    {
+      "id": "a1f2c3d4-0003-4a1b-8c2d-100000000003",
+      "name": "Get Live Matches",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [
+        1240,
+        280
+      ],
+      "parameters": {
+        "url": "https://api.livetennisapi.com/api/public/v1/matches",
+        "options": {},
+        "sendQuery": true,
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "status",
+              "value": "live"
+            }
+          ]
+        }
+      },
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "REPLACE_WITH_HEADER_AUTH_CRED",
+          "name": "Live Tennis API (X-API-Key)"
+        }
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "a1f2c3d4-0004-4a1b-8c2d-100000000004",
+      "name": "Split Out Matches",
+      "type": "n8n-nodes-base.splitOut",
+      "position": [
+        1460,
+        280
+      ],
+      "parameters": {
+        "options": {},
+        "fieldToSplitOut": "data"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "a1f2c3d4-0005-4a1b-8c2d-100000000005",
+      "name": "Only New Matches",
+      "type": "n8n-nodes-base.removeDuplicates",
+      "position": [
+        1680,
+        280
+      ],
+      "parameters": {
+        "options": {},
+        "operation": "removeItemsSeenInPreviousExecutions",
+        "dedupeValue": "={{ $json.id }}"
+      },
+      "typeVersion": 2
+    },
+    {
+      "id": "a1f2c3d4-0006-4a1b-8c2d-100000000006",
+      "name": "Discord",
+      "type": "n8n-nodes-base.discord",
+      "position": [
+        1900,
+        280
+      ],
+      "parameters": {
+        "content": "=🎾 New live match: {{ $json.players.p1.name }} vs {{ $json.players.p2.name }} — {{ $json.status }}",
+        "options": {},
+        "authentication": "webhook"
+      },
+      "credentials": {
+        "discordWebhookApi": {
+          "id": "REPLACE_WITH_DISCORD_WEBHOOK_CRED",
+          "name": "Discord Webhook"
+        }
+      },
+      "typeVersion": 2
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Get Live Matches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Live Matches": {
+      "main": [
+        [
+          {
+            "node": "Split Out Matches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Out Matches": {
+      "main": [
+        [
+          {
+            "node": "Only New Matches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Only New Matches": {
+      "main": [
+        [
+          {
+            "node": "Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -246,13 +246,14 @@ Find 11 PDF and document processing templates for n8n. These workflows handle AI
 
 ### How can I automate Discord with n8n?
 
-This section contains 3 Discord automation templates for n8n. Build an AI-powered Discord bot that routes messages to the right department, automate daily comic translations and posts, or share YouTube videos with AI-generated summaries directly to your Discord server.
+This section contains 4 Discord automation templates for n8n. Build an AI-powered Discord bot that routes messages to the right department, automate daily comic translations and posts, share YouTube videos with AI-generated summaries, or post newly live tennis matches to a Discord channel on a schedule.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
 | Discord AI-powered bot | This workflow creates an AI-powered Discord bot that categorizes user messages (success story, urgent issue, ticket) and routes them to the appropriate department (customer success, IT, customer support). | Customer Support | [Link to Template](Discord/Discord%20AI-powered%20bot.json) |
 | Send daily translated Calvin and Hobbes Comics to Discord | This workflow automates the daily retrieval of Calvin and Hobbes comics, translates the dialogues into English and Korean (or other languages), and posts them to Discord. | Marketing/Content | [Link to Template](Discord/Send%20daily%20translated%20Calvin%20and%20Hobbes%20Comics%20to%20Discord.json) |
 | Share YouTube Videos with AI Summaries on Discord | This workflow automatically shares new YouTube videos on Discord along with AI-generated summaries of their content, leveraging caption data. | Marketing | [Link to Template](Discord/Share%20YouTube%20Videos%20with%20AI%20Summaries%20on%20Discord.json) |
+| Post New Live Tennis Matches to Discord on a Schedule | Every 5 minutes, fetches the currently live tennis matches from the Live Tennis API, keeps only the ones newly in progress (deduplicated across executions), and posts a one-line alert (players and match status) to a Discord channel via a webhook. Free API tier, no card. | Data / Notifications | [Link to Template](Discord/Post%20New%20Live%20Tennis%20Matches%20to%20Discord%20on%20a%20Schedule.json) |
 
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />


### PR DESCRIPTION
Adds a Discord automation template + its README row (Discord section, count 3→4).

**Disclosure:** contributed by the team behind the Live Tennis API — judge it on the merits.

**What it does:** every 5 minutes it fetches currently-live tennis matches from the Live Tennis API, keeps only matches newly in progress (dedup across executions on match `id`), and posts a one-line alert (players + status) to a Discord channel via a webhook.

**Nodes:** Schedule Trigger → HTTP Request (Header Auth `X-API-Key`) → Split Out → Remove Duplicates → Discord (webhook). No credentials/secrets are embedded — the HTTP key and the Discord webhook are added as n8n credentials (setup is in a sticky note). Field paths match the API schema (`data[]`, `players.p1.name`/`players.p2.name`, `status`).

- Free key, no card: https://livetennisapi.com/subscribe/free (30/min, 100/day — a 5-min schedule stays well within limits)
- Optional: swap the HTTP Request for the community node `n8n-nodes-livetennisapi`.