### PR TITLE
Add public-page automation acceptance pack workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,11 @@ Find 5 database and storage automation templates for n8n. Chat with PostgreSQL u
 
 ### What n8n templates are available for DevOps and server automation?
 
-This section includes 5 DevOps and reliability templates for n8n. Trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely, watch disk usage across mountpoints, diagnose failed n8n execution JSON without connecting to a live instance, or get a Telegram alert only when a site's up/down state changes.
+This section includes 6 DevOps and reliability templates for n8n. Audit a public page and build an implementation acceptance pack, trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely, watch disk usage across mountpoints, diagnose failed n8n execution JSON without connecting to a live instance, or get a Telegram alert only when a site's up/down state changes.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
+| Audit a Public Page and Build an Automation Acceptance Pack | Validate one public URL, collect bounded integration-readiness evidence, generate launch gates and acceptance tests, and route the result for implementation or review. | Engineering | [Link to Template](devops/Audit%20a%20Public%20Page%20and%20Build%20an%20Automation%20Acceptance%20Pack.json) |
 | Linux System Update via Webhook | Trigger update & upgrade of your Debian-based server via an authenticated POST request and SSH. | SSH Tools | [Link to Template](devops/linux-update-via-webhook.json)
 | Docker Compose Controller via Webhook | Start or stop Docker Compose services on your server via authenticated HTTP POST request with n8n + SSH. | SSH Tools | [Link to Template](devops/docker-compose-controller.json) |
 | Disk Space Watchdog with Tiered Thresholds | Check disk usage over SSH on a schedule, warn at 80% and 90%, and alert only when a mountpoint changes level - no repeated alerts for the same full disk. Telegram with e-mail fallback. | SSH Tools | [Link to Template](devops/disk-space-watchdog.json) |

--- a/devops/Audit a Public Page and Build an Automation Acceptance Pack.json
+++ b/devops/Audit a Public Page and Build an Automation Acceptance Pack.json
@@ -1,0 +1,259 @@
+{
+  "name": "Audit a Public Page and Build an Automation Acceptance Pack",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "6c13d54f-98c8-4c0b-a9d3-410c116e8785",
+      "name": "Run Workflow",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -760,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "097a7a7a-dd23-4f0d-91c4-b64e80898daa",
+              "name": "targetUrl",
+              "value": "https://example.com",
+              "type": "string"
+            },
+            {
+              "id": "b95d6346-2a2a-41a7-ad95-08d6af06d4dc",
+              "name": "objective",
+              "value": "Verify this public page before implementing an automation or integration.",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "21dcc9b6-baca-4679-b139-b8a78e82293c",
+      "name": "Set Target and Objective",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -540,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const config = $input.first().json;\nconst rawTarget = String(config.targetUrl || '').trim();\nconst objective = String(config.objective || '').trim();\n\nif (!rawTarget) throw new Error('targetUrl is required');\nif (!objective) throw new Error('objective is required');\nif (objective.length > 500) throw new Error('objective must be 500 characters or fewer');\n\nlet target;\ntry {\n  target = new URL(rawTarget);\n} catch {\n  throw new Error('targetUrl must be a valid public HTTP or HTTPS URL');\n}\nif (!['http:', 'https:'].includes(target.protocol)) {\n  throw new Error('targetUrl must use HTTP or HTTPS');\n}\nconst hostname = target.hostname.toLowerCase();\nconst privateHost = hostname === 'localhost'\n  || hostname.endsWith('.local')\n  || hostname === '0.0.0.0'\n  || hostname === '127.0.0.1'\n  || hostname === '::1'\n  || /^10\\./.test(hostname)\n  || /^192\\.168\\./.test(hostname)\n  || /^169\\.254\\./.test(hostname)\n  || /^172\\.(1[6-9]|2\\d|3[01])\\./.test(hostname);\nif (privateHost) throw new Error('targetUrl must resolve to a public host');\n\nreturn [{ json: { targetUrl: target.toString(), objective } }];\n"
+      },
+      "id": "98f56bd3-526d-41f8-82c6-d5a96279df3c",
+      "name": "Validate Public Target",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -300,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://automation-integration-preflight.p.rapidapi.com/rapidapi/analyze",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-rapidapi-host",
+              "value": "automation-integration-preflight.p.rapidapi.com"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ url: $json.targetUrl, mode: 'acceptance-pack', objective: $json.objective }) }}",
+        "options": {
+          "timeout": 45000
+        }
+      },
+      "id": "c781455a-6217-4cb5-b9fb-596f4e75bdba",
+      "name": "Build Acceptance Pack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        -40,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const report = $input.first().json;\nconst readiness = report.readiness && typeof report.readiness === 'object' ? report.readiness : {};\nconst pack = report.acceptance_pack && typeof report.acceptance_pack === 'object' ? report.acceptance_pack : {};\nconst gate = pack.launch_gate && typeof pack.launch_gate === 'object' ? pack.launch_gate : {};\nconst score = Number(readiness.score || 0);\nconst riskFlags = Array.isArray(readiness.risk_flags) ? readiness.risk_flags : [];\nconst acceptanceTests = Array.isArray(pack.acceptance_tests) ? pack.acceptance_tests : [];\nconst backlog = Array.isArray(pack.prioritized_backlog) ? pack.prioritized_backlog : [];\nconst requiresAttention = gate.decision !== 'ready' || score < 80 || riskFlags.length > 0;\n\nreturn [{ json: {\n  targetUrl: report.target?.final_url || report.target?.requested_url || null,\n  objective: pack.objective || null,\n  readinessScore: score,\n  readinessGrade: readiness.grade || null,\n  launchDecision: gate.decision || 'unknown',\n  riskFlags,\n  acceptanceTestCount: acceptanceTests.length,\n  backlogCount: backlog.length,\n  requiresAttention,\n  acceptancePack: pack,\n  evidence: {\n    target: report.target || null,\n    page: report.page || null,\n    security: report.security_headers || null,\n    readiness\n  }\n} }];\n"
+      },
+      "id": "829a62ae-3f93-4c9f-9077-28025bfd2af0",
+      "name": "Summarize Evidence",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "b6040ef2-29f5-4f69-8c37-200211e7bd9f",
+              "leftValue": "={{ $json.requiresAttention }}",
+              "rightValue": "",
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "6fe1783d-f3fd-4518-a5ac-3dbfb84b0fdd",
+      "name": "Needs Attention?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        480,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map((item) => ({ json: { ...item.json, workflowDecision: 'NEEDS_REVIEW', nextStep: 'Work through the P0 and P1 backlog items, then rerun the preflight.' } }));\n"
+      },
+      "id": "4dcb04c4-aa72-4ac1-82a0-6bf558da6c1e",
+      "name": "Mark Needs Review",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        740,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map((item) => ({ json: { ...item.json, workflowDecision: 'READY_TO_IMPLEMENT', nextStep: 'Use the acceptance tests as the implementation and launch checklist.' } }));\n"
+      },
+      "id": "67095850-d391-4ae0-830d-26b89f5f2f8f",
+      "name": "Mark Ready to Implement",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        740,
+        280
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## Public-page automation preflight\n\n1. Subscribe to Automation Integration Preflight on RapidAPI. The BASIC plan includes a small free request allowance.\n2. In n8n, create a Header Auth credential with header name `x-rapidapi-key` and your RapidAPI application key.\n3. Select that credential on **Build Acceptance Pack**.\n4. Edit **Set Target and Objective**, then run the workflow.\n\nThe workflow reads public server-rendered HTML only. It does not log in, submit forms, execute page JavaScript, or bypass access controls. The output keeps the evidence, launch gate, acceptance tests, and prioritized backlog together for implementation review.\n\nAPI: https://rapidapi.com/tinyopsstudio/api/automation-integration-preflight",
+        "height": 430,
+        "width": 540
+      },
+      "id": "0613676a-a709-4e1a-be34-230709072041",
+      "name": "Setup and Safety Notes",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -760,
+        -320
+      ]
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Run Workflow": {
+      "main": [
+        [
+          {
+            "node": "Set Target and Objective",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Target and Objective": {
+      "main": [
+        [
+          {
+            "node": "Validate Public Target",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Public Target": {
+      "main": [
+        [
+          {
+            "node": "Build Acceptance Pack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Acceptance Pack": {
+      "main": [
+        [
+          {
+            "node": "Summarize Evidence",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Summarize Evidence": {
+      "main": [
+        [
+          {
+            "node": "Needs Attention?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Attention?": {
+      "main": [
+        [
+          {
+            "node": "Mark Needs Review",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mark Ready to Implement",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "id": "c572a3e2-eead-4fb6-bc82-15caef15d3b1",
+  "versionId": "db28af55-d4a4-48df-886d-6f1c4194e38a"
+}


### PR DESCRIPTION
## What this adds

- A nine-node n8n workflow that validates one public target before any network request.
- A bounded RapidAPI call that returns readiness evidence, launch gates, acceptance tests, and a prioritized backlog.
- A decision branch that marks the result ready to implement or in need of review.
- Setup and safety notes inside the workflow.

## Validation

- Imported successfully with n8n 2.0.0 on Node 22.
- Exercised against the live API with HTTP 200, eight acceptance tests, and the review branch.
- Passed 30 structural and behavioral assertions.
- Contains no credentials, API keys, or private identity data.