### PR TITLE
Add three templates: EU business registers and ATS hiring watch

### DIFF
--- a/Forms_and_Surveys/Check a company in seven EU business registers from a form.json
+++ b/Forms_and_Surveys/Check a company in seven EU business registers from a form.json
@@ -1,0 +1,301 @@
+{
+  "name": "Check a company in seven EU business registers from a form",
+  "nodes": [
+    {
+      "parameters": {
+        "formTitle": "Company check",
+        "formDescription": "Enter a company name or a registration number. The official register of the country is read directly.",
+        "formFields": {
+          "values": [
+            {
+              "fieldLabel": "Company name or registration number",
+              "placeholder": "Bolt, or cz:27074358",
+              "requiredField": true
+            },
+            {
+              "fieldLabel": "Country",
+              "fieldType": "dropdown",
+              "fieldOptions": {
+                "values": [
+                  {
+                    "option": "cz"
+                  },
+                  {
+                    "option": "ee"
+                  },
+                  {
+                    "option": "fi"
+                  },
+                  {
+                    "option": "fr"
+                  },
+                  {
+                    "option": "no"
+                  },
+                  {
+                    "option": "pl"
+                  },
+                  {
+                    "option": "sk"
+                  }
+                ]
+              },
+              "requiredField": true
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a1000000-0000-4000-8000-000000000001",
+      "name": "Someone submits the form",
+      "type": "n8n-nodes-base.formTrigger",
+      "typeVersion": 2.2,
+      "position": [
+        -220,
+        0
+      ],
+      "webhookId": "b1000000-0000-4000-8000-000000000001"
+    },
+    {
+      "parameters": {
+        "authentication": "apifyApi",
+        "resource": "Actors",
+        "operation": "Run actor and get dataset",
+        "actorSource": "store",
+        "actorId": "gubidonius~company-registry-lookup",
+        "customBody": "={{ JSON.stringify({ queries: [$json['Company name or registration number']], countries: [$json['Country']], maxResultsPerQuery: 5, onlyActive: false }) }}",
+        "timeout": 600,
+        "memory": 1024,
+        "build": ""
+      },
+      "id": "a1000000-0000-4000-8000-000000000002",
+      "name": "Look up the official register",
+      "type": "@apify/n8n-nodes-apify.apify",
+      "typeVersion": 1,
+      "position": [
+        20,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": false,
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1000000-0000-4000-8000-000000000001",
+              "leftValue": "={{ $json.status }}",
+              "rightValue": "active",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "a1000000-0000-4000-8000-000000000003",
+      "name": "Is the company still active",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "d1",
+              "name": "verdict",
+              "value": "ok",
+              "type": "string"
+            },
+            {
+              "id": "d2",
+              "name": "company",
+              "value": "={{ $json.name }}",
+              "type": "string"
+            },
+            {
+              "id": "d3",
+              "name": "registrationNumber",
+              "value": "={{ $json.registrationNumber }}",
+              "type": "string"
+            },
+            {
+              "id": "d4",
+              "name": "country",
+              "value": "={{ $json.countryName }}",
+              "type": "string"
+            },
+            {
+              "id": "d5",
+              "name": "legalForm",
+              "value": "={{ $json.legalFormCode }}",
+              "type": "string"
+            },
+            {
+              "id": "d6",
+              "name": "address",
+              "value": "={{ $json.address }}",
+              "type": "string"
+            },
+            {
+              "id": "d7",
+              "name": "vatNumber",
+              "value": "={{ $json.vatNumber }}",
+              "type": "string"
+            },
+            {
+              "id": "d8",
+              "name": "registryUrl",
+              "value": "={{ $json.registryUrl }}",
+              "type": "string"
+            },
+            {
+              "id": "d9",
+              "name": "registryUpdatedAt",
+              "value": "={{ $json.registryUpdatedAt }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a1000000-0000-4000-8000-000000000004",
+      "name": "Passed, keep the register fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        520,
+        -100
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "e1",
+              "name": "verdict",
+              "value": "check by hand",
+              "type": "string"
+            },
+            {
+              "id": "e2",
+              "name": "company",
+              "value": "={{ $json.name }}",
+              "type": "string"
+            },
+            {
+              "id": "e3",
+              "name": "status",
+              "value": "={{ $json.status }}",
+              "type": "string"
+            },
+            {
+              "id": "e4",
+              "name": "statusRaw",
+              "value": "={{ $json.statusRaw }}",
+              "type": "string"
+            },
+            {
+              "id": "e5",
+              "name": "dissolvedAt",
+              "value": "={{ $json.dissolvedAt }}",
+              "type": "string"
+            },
+            {
+              "id": "e6",
+              "name": "registryUrl",
+              "value": "={{ $json.registryUrl }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a1000000-0000-4000-8000-000000000005",
+      "name": "Not active, send it to a human",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        520,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## What this does\n\nSomebody types a company name or a registration number into a form. The workflow reads that company straight out of the country's official business register and answers one question, which is whether the company is still active.\n\nSeven registers are covered and all of them return the same field names, so nothing downstream has to know which country it got.\n\nCzechia (ARES), Estonia (Ariregister), Finland (PRH), France (Annuaire des Entreprises), Norway (Bronnoysund), Poland (MF VAT list), Slovakia (RPO).\n\n## Setup\n\n1. Install the Apify node. It is verified by n8n, so it works on Cloud and on self-hosted.\n2. Add your Apify API key in the node credentials. A free Apify account is enough to start.\n3. Open the form URL on the trigger node.\n\nThe Actor is gubidonius/company-registry-lookup. It reads the government API of each\ncountry directly, so there is no login to any register and no personal data is returned.\n",
+        "height": 460,
+        "width": 420,
+        "color": 4
+      },
+      "id": "a1000000-0000-4000-8000-000000000006",
+      "name": "Read me",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -700,
+        -140
+      ]
+    }
+  ],
+  "connections": {
+    "Someone submits the form": {
+      "main": [
+        [
+          {
+            "node": "Look up the official register",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Look up the official register": {
+      "main": [
+        [
+          {
+            "node": "Is the company still active",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is the company still active": {
+      "main": [
+        [
+          {
+            "node": "Passed, keep the register fields",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Not active, send it to a human",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  }
+}

--- a/Google_Drive_and_Google_Sheets/Enrich a Google Sheet of companies with EU business register data.json
+++ b/Google_Drive_and_Google_Sheets/Enrich a Google Sheet of companies with EU business register data.json
@@ -1,0 +1,247 @@
+{
+  "name": "Enrich a Google Sheet of companies with EU business register data",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a2000000-0000-4000-8000-000000000001",
+      "name": "Run it",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "documentId": {
+          "__rl": true,
+          "value": "",
+          "mode": "list",
+          "cachedResultName": "Companies"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "gid=0",
+          "mode": "list",
+          "cachedResultName": "Sheet1"
+        },
+        "options": {}
+      },
+      "id": "a2000000-0000-4000-8000-000000000002",
+      "name": "Read the sheet",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.5,
+      "position": [
+        20,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "apifyApi",
+        "resource": "Actors",
+        "operation": "Run actor and get dataset",
+        "actorSource": "store",
+        "actorId": "gubidonius~company-registry-lookup",
+        "customBody": "={{ JSON.stringify({ queries: [$json.company], countries: ['cz','ee','fi','fr','no','pl','sk'], maxResultsPerQuery: 1, onlyActive: true }) }}",
+        "timeout": 600,
+        "memory": 1024,
+        "build": ""
+      },
+      "id": "a2000000-0000-4000-8000-000000000003",
+      "name": "Look up the official register",
+      "type": "@apify/n8n-nodes-apify.apify",
+      "typeVersion": 1,
+      "position": [
+        260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "f1",
+              "name": "company",
+              "value": "={{ $json.name }}",
+              "type": "string"
+            },
+            {
+              "id": "f2",
+              "name": "registrationNumber",
+              "value": "={{ $json.registrationNumber }}",
+              "type": "string"
+            },
+            {
+              "id": "f3",
+              "name": "vatNumber",
+              "value": "={{ $json.vatNumber }}",
+              "type": "string"
+            },
+            {
+              "id": "f4",
+              "name": "country",
+              "value": "={{ $json.countryName }}",
+              "type": "string"
+            },
+            {
+              "id": "f5",
+              "name": "registry",
+              "value": "={{ $json.registry }}",
+              "type": "string"
+            },
+            {
+              "id": "f6",
+              "name": "status",
+              "value": "={{ $json.status }}",
+              "type": "string"
+            },
+            {
+              "id": "f7",
+              "name": "incorporatedAt",
+              "value": "={{ $json.incorporatedAt }}",
+              "type": "string"
+            },
+            {
+              "id": "f8",
+              "name": "address",
+              "value": "={{ $json.address }}",
+              "type": "string"
+            },
+            {
+              "id": "f9",
+              "name": "city",
+              "value": "={{ $json.city }}",
+              "type": "string"
+            },
+            {
+              "id": "f10",
+              "name": "website",
+              "value": "={{ $json.website }}",
+              "type": "string"
+            },
+            {
+              "id": "f11",
+              "name": "registryUrl",
+              "value": "={{ $json.registryUrl }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a2000000-0000-4000-8000-000000000004",
+      "name": "Keep the columns worth writing back",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        500,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "appendOrUpdate",
+        "documentId": {
+          "__rl": true,
+          "value": "",
+          "mode": "list",
+          "cachedResultName": "Companies"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "gid=0",
+          "mode": "list",
+          "cachedResultName": "Sheet1"
+        },
+        "columns": {
+          "mappingMode": "autoMapInputData",
+          "matchingColumns": [
+            "company"
+          ],
+          "value": {}
+        },
+        "options": {}
+      },
+      "id": "a2000000-0000-4000-8000-000000000005",
+      "name": "Write it back to the sheet",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.5,
+      "position": [
+        740,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "content": "## What this does\n\nYou have a sheet with a column called company, holding names or registration numbers. This fills in the official register data next to each one and writes it back.\n\nEvery country returns the same field names, so one set of columns works for all seven. No mapping per country.\n\nCzechia (ARES), Estonia (Ariregister), Finland (PRH), France (Annuaire des Entreprises), Norway (Bronnoysund), Poland (MF VAT list), Slovakia (RPO).\n\n## Setup\n\n1. Install the Apify node. It is verified by n8n, so it works on Cloud and on self-hosted.\n2. Add your Apify API key in the node credentials. A free Apify account is enough to start.\n3. Point the two Google Sheets nodes at your sheet. Column A holds the company names.\n\nThe Actor is gubidonius/company-registry-lookup. One row comes back per company with the\nsame 28 field names whichever of the seven registers answered.\n",
+        "height": 520,
+        "width": 420,
+        "color": 4
+      },
+      "id": "a2000000-0000-4000-8000-000000000006",
+      "name": "Read me",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -700,
+        -160
+      ]
+    }
+  ],
+  "connections": {
+    "Run it": {
+      "main": [
+        [
+          {
+            "node": "Read the sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read the sheet": {
+      "main": [
+        [
+          {
+            "node": "Look up the official register",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Look up the official register": {
+      "main": [
+        [
+          {
+            "node": "Keep the columns worth writing back",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keep the columns worth writing back": {
+      "main": [
+        [
+          {
+            "node": "Write it back to the sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  }
+}

--- a/Other_Integrations_and_Use_Cases/Watch competitor hiring across four ATS job boards.json
+++ b/Other_Integrations_and_Use_Cases/Watch competitor hiring across four ATS job boards.json
@@ -1,0 +1,255 @@
+{
+  "name": "Watch competitor hiring across four ATS job boards",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "days",
+              "triggerAtHour": 8,
+              "triggerAtMinute": 0
+            }
+          ]
+        }
+      },
+      "id": "a3000000-0000-4000-8000-000000000001",
+      "name": "Every morning at eight",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "g1",
+              "name": "companies",
+              "value": "={{ [\"https://boards.greenhouse.io/stripe\", \"lever:leverdemo\", \"ramp\"] }}",
+              "type": "array"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a3000000-0000-4000-8000-000000000002",
+      "name": "Companies to watch",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "apifyApi",
+        "resource": "Actors",
+        "operation": "Run actor and get dataset",
+        "actorSource": "store",
+        "actorId": "gubidonius~company-jobs-scraper",
+        "customBody": "={{ JSON.stringify({ companies: $json.companies, includeDescription: false, onlyRemote: false, maxJobsPerCompany: 1000 }) }}",
+        "timeout": 900,
+        "memory": 1024,
+        "build": ""
+      },
+      "id": "a3000000-0000-4000-8000-000000000003",
+      "name": "Read every board",
+      "type": "@apify/n8n-nodes-apify.apify",
+      "typeVersion": 1,
+      "position": [
+        220,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "removeItemsSeenInPreviousExecutions",
+        "logic": "removeItemsWithAlreadySeenKeyValues",
+        "dedupeValue": "={{ $json.platform }}:{{ $json.companySlug }}:{{ $json.jobId }}",
+        "options": {
+          "scope": "node",
+          "historySize": 20000
+        }
+      },
+      "id": "a3000000-0000-4000-8000-000000000004",
+      "name": "Only the ones I have not seen",
+      "type": "n8n-nodes-base.removeDuplicates",
+      "typeVersion": 2,
+      "position": [
+        460,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "h1",
+              "name": "company",
+              "value": "={{ $json.company || $json.companySlug }}",
+              "type": "string"
+            },
+            {
+              "id": "h2",
+              "name": "title",
+              "value": "={{ $json.title }}",
+              "type": "string"
+            },
+            {
+              "id": "h3",
+              "name": "location",
+              "value": "={{ $json.location }}",
+              "type": "string"
+            },
+            {
+              "id": "h4",
+              "name": "department",
+              "value": "={{ $json.department }}",
+              "type": "string"
+            },
+            {
+              "id": "h5",
+              "name": "remote",
+              "value": "={{ $json.isRemote }}",
+              "type": "boolean"
+            },
+            {
+              "id": "h6",
+              "name": "postedAt",
+              "value": "={{ $json.postedAt }}",
+              "type": "string"
+            },
+            {
+              "id": "h7",
+              "name": "applyUrl",
+              "value": "={{ $json.applyUrl }}",
+              "type": "string"
+            },
+            {
+              "id": "h8",
+              "name": "board",
+              "value": "={{ $json.platform }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "a3000000-0000-4000-8000-000000000005",
+      "name": "Keep what is worth reading",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        700,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "select": "channel",
+        "channelId": {
+          "__rl": true,
+          "value": "hiring-watch",
+          "mode": "name"
+        },
+        "text": "={{ $json.company }} is hiring: {{ $json.title }} ({{ $json.location }}) {{ $json.applyUrl }}",
+        "otherOptions": {}
+      },
+      "id": "a3000000-0000-4000-8000-000000000006",
+      "name": "Tell the channel",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.3,
+      "position": [
+        940,
+        0
+      ],
+      "webhookId": "b3000000-0000-4000-8000-000000000001"
+    },
+    {
+      "parameters": {
+        "content": "## What this does\n\nEvery morning it reads the career boards of the companies you list and tells you only the\nadverts that are new since yesterday. Nothing else is repeated, so the message is short\nenough to actually read.\n\nGreenhouse, Lever, Ashby and SmartRecruiters are covered. Give a board URL, a\n\"platform:slug\" like lever:leverdemo, or just the company slug and all four are tried.\n\nNew job adverts are the earliest public sign of what a company is building, which team is\ngrowing, and which office is being staffed. Sales teams watch them for a reason to call.\n\n## Setup\n\n1. Install the Apify node. It is verified by n8n, so it works on Cloud and on self-hosted.\n2. Add your Apify API key in the node credentials. A free Apify account is enough to start.\n3. Put your companies in the \"Companies to watch\" node.\n4. Point the Slack node at a channel, or delete it and connect whatever you use instead.\n\nThe Actor is gubidonius/company-jobs-scraper. These are the boards' own public JSON\nendpoints, so there is no login and no proxy to configure.",
+        "height": 560,
+        "width": 440,
+        "color": 4
+      },
+      "id": "a3000000-0000-4000-8000-000000000007",
+      "name": "Read me",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -720,
+        -160
+      ]
+    }
+  ],
+  "connections": {
+    "Every morning at eight": {
+      "main": [
+        [
+          {
+            "node": "Companies to watch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Companies to watch": {
+      "main": [
+        [
+          {
+            "node": "Read every board",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read every board": {
+      "main": [
+        [
+          {
+            "node": "Only the ones I have not seen",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Only the ones I have not seen": {
+      "main": [
+        [
+          {
+            "node": "Keep what is worth reading",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keep what is worth reading": {
+      "main": [
+        [
+          {
+            "node": "Tell the channel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Explore 20 Telegram automation templates for n8n, including AI chatbots with Lan
 
 ### What are the best n8n templates for Google Drive and Google Sheets?
 
-Browse 17 Google Drive and Google Sheets automation templates for n8n. Includes RAG chatbots for company documents, OpenAI model fine-tuning pipelines, automated background removal, lead qualification and routing, applicant screening for HR, and document summarization workflows. Perfect for operations, sales, marketing, and engineering teams.
+Browse 18 Google Drive and Google Sheets automation templates for n8n. Includes RAG chatbots for company documents, OpenAI model fine-tuning pipelines, automated background removal, lead qualification and routing, applicant screening for HR, and document summarization workflows. Perfect for operations, sales, marketing, and engineering teams.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -200,6 +200,7 @@ Browse 17 Google Drive and Google Sheets automation templates for n8n. Includes 
 | Screen Applicants With AI, notify HR and save them in a Google Sheet | Automates the screening of job applicants using AI, notifies HR of qualified candidates, and saves applicant data into a Google Sheet. | HR | [Link to Template](Google_Drive_and_Google_Sheets/Screen%20Applicants%20With%20AI,%20notify%20HR%20and%20save%20them%20in%20a%20Google%20Sheet.json) |
 | Summarize Google Sheets form feedback via OpenAI's GPT-4 | Summarizes feedback collected through Google Forms and stored in Google Sheets using OpenAI's GPT-4, providing quick insights from survey responses. | Marketing | [Link to Template](Google_Drive_and_Google_Sheets/Summarize%20Google%20Sheets%20form%20feedback%20via%20OpenAI_s%20GPT-4.json) |
 | Airtable to Google Sheets Auto-Sync | Automates bidirectional sync between Airtable and Google Sheets using n8n. Searches Airtable for recently updated records and upserts them into Google Sheets. | Ops | [Link to Template](Google_Drive_and_Google_Sheets/Airtable%20to%20Google%20Sheets%20Auto-Sync.json) |
+| Enrich a Google Sheet of companies with EU business register data | Takes a column of company names from a Google Sheet, looks each one up in the official register of seven European countries, and writes the registration number, VAT number, status and address back to the sheet. | Sales/Ops | [Link to Template](Google_Drive_and_Google_Sheets/Enrich%20a%20Google%20Sheet%20of%20companies%20with%20EU%20business%20register%20data.json) |
 
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />
@@ -436,7 +437,7 @@ Explore 13 social media automation templates for n8n covering Instagram, Twitter
 
 ### What other n8n integration templates are available?
 
-This section includes 45 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pennylane invoice automation, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
+This section includes 46 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pennylane invoice automation, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -485,13 +486,14 @@ This section includes 45 additional n8n integration templates covering a wide ra
 | Generate Seedance videos with Vancine API and bounded polling | Submits a Seedance video generation task, polls its asynchronous status, and handles completion, failure, and bounded timeout paths. | Engineering | [Link to Template](Other_Integrations_and_Use_Cases/Generate%20Seedance%20videos%20with%20Vancine%20API%20and%20bounded%20polling.json) |
 | Issue a Verifiable Certificate (Attestify API) | POST recipient and course data to a free API and receive a permanent, tamper-evident public verify page (Ed25519-signed — change one character and verification fails). Core HTTP node; no API key, no signup. | Education/Ops | [Link to Template](Other_Integrations_and_Use_Cases/Issue%20a%20verifiable%20certificate%20(Attestify).json) |
 | Transport Request Intake Lite | Free n8n workflow for normalizing a simple transport request and validating required fields. | Ops/Sales | [Link to Template](Other_Integrations_and_Use_Cases/Transport_Request_Intake_Lite.json) |
+| Watch competitor hiring across four ATS job boards | Reads the Greenhouse, Lever, Ashby and SmartRecruiters boards of the companies you list every morning and reports only the adverts that are new since the previous run. Uses the verified Apify node, so it works on n8n Cloud. | Sales/HR | [Link to Template](Other_Integrations_and_Use_Cases/Watch%20competitor%20hiring%20across%20four%20ATS%20job%20boards.json) |
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />
 <small>* Referral link — this project receives a commission on eligible purchases.</small>
 
 ### How do I automate forms and surveys with n8n?
 
-This section contains 4 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, or qualify appointment requests using AI. These templates streamline data collection and lead processing workflows.
+This section contains 5 form and survey automation templates for n8n. Conduct AI-powered conversational interviews via n8n Forms, manage email subscriptions with Airtable integration, or qualify appointment requests using AI. These templates streamline data collection and lead processing workflows.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -499,6 +501,7 @@ This section contains 4 form and survey automation templates for n8n. Conduct AI
 | Email Subscription Service with n8n Forms, Airtable and AI | Manages email subscriptions with n8n Forms, stores data in Airtable, and uses AI for processing. | Marketing/Communication | [Link to Template](Forms_and_Surveys/Email%20Subscription%20Service%20with%20n8n%20Forms,%20Airtable%20and%20AI.json) |
 | Generate a Song from a Form (Tunova) | A hosted n8n Form collects a text prompt, then Tunova generates an original Suno AI song (v5.5) and returns the audio URL. Core HTTP node — runs on any n8n. Free API key at tunova.ai. | Marketing/Creative | [Link to Template](Forms_and_Surveys/Tunova%20-%20Generate%20a%20song%20from%20a%20form.json) |
 | Qualifying Appointment Requests with AI & n8n Forms | Uses AI to qualify and process appointment requests submitted through n8n Forms. | Sales/Support | [Link to Template](Forms_and_Surveys/Qualifying%20Appointment%20Requests%20with%20AI%20&%20n8n%20Forms.json) |
+| Check a company in seven EU business registers from a form | Somebody submits a company name or registration number through an n8n Form and the workflow reads the official business register of Czechia, Estonia, Finland, France, Norway, Poland or Slovakia, then branches on whether the company is still active. | Finance/Ops | [Link to Template](Forms_and_Surveys/Check%20a%20company%20in%20seven%20EU%20business%20registers%20from%20a%20form.json) |
 
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />


### PR DESCRIPTION
Hi @enescingoz,

Three templates, all built on the Apify node that n8n has verified, so they install and run on n8n Cloud and not only on self-hosted.

| Template | Category | What it does |
|---|---|---|
| Watch competitor hiring across four ATS job boards | Other_Integrations_and_Use_Cases | Reads Greenhouse, Lever, Ashby and SmartRecruiters every morning and reports only the adverts that are new since the previous run |
| Check a company in seven EU business registers from a form | Forms_and_Surveys | An n8n Form takes a company name, the workflow reads the official register and branches on whether the company is still active |
| Enrich a Google Sheet of companies with EU business register data | Google_Drive_and_Google_Sheets | A column of company names goes in, registration number, VAT number, status and address come back |

The registers are Czechia, Estonia, Finland, France, Norway, Poland and Slovakia, all through the government APIs, so there is no login and no personal data.

## Checked before opening this

- No credentials block on any node, and no keys or tokens anywhere in the JSON.
- Every field name used in an expression was read from a real run, not from a schema. The register output has no `isActive` field, status is a string.
- The ATS field names were taken from the boards themselves. `company` is genuinely absent from Lever and Ashby responses, so the workflow fills it from the slug.
- Connections, node ids and reachability validated by a script that loads the real Apify node description and checks every parameter name against it.
- The Google Sheets nodes have an empty `documentId` on purpose. You pick your own sheet.

## README

One row added to each of the three category tables, plus the two counts those sections state, 17 to 18 and 45 to 46.

Disclosure: both Actors are mine, and they are pay per event, about a cent to try. The workflow JSON is MIT and the field notes above hold either way.
