### PR TITLE
Add three Shopify starter templates (Other Integrations)

### DIFF
--- a/Other_Integrations_and_Use_Cases/Shopify new customer welcome email.json
+++ b/Other_Integrations_and_Use_Cases/Shopify new customer welcome email.json
@@ -1,0 +1,126 @@
+{
+  "name": "Shopify New Customer Welcome Email (Free Starter)",
+  "nodes": [
+    {
+      "id": "aa000003-3333-4a33-9b33-000000000033",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -40,
+        40
+      ],
+      "parameters": {
+        "content": "## Shopify → Gmail welcome email\n\nEmails a welcome to each new Shopify customer, sent from your own Gmail.\n\n**Setup**\n1. Add your Shopify Admin API and Gmail credentials.\n2. Edit the subject and message to match your brand.\n3. Save and activate.\n\nGuide: https://www.easyworkflows.net/shopify-new-customer-welcome-gmail-n8n/",
+        "height": 240,
+        "width": 760,
+        "color": 4
+      }
+    },
+    {
+      "id": "f3c30001-0001-4c01-9d01-3e01f01a0001",
+      "name": "New Shopify customer",
+      "type": "n8n-nodes-base.shopifyTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        300
+      ],
+      "parameters": {
+        "topic": "customers/create",
+        "authentication": "accessToken"
+      },
+      "credentials": {
+        "shopifyAccessTokenApi": {
+          "id": "YOUR_SHOPIFY_CREDENTIAL_ID",
+          "name": "Your Shopify account"
+        }
+      }
+    },
+    {
+      "id": "f3c30002-0002-4c02-9d02-3e02f02a0002",
+      "name": "Prepare welcome",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        260,
+        300
+      ],
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "e",
+              "name": "email",
+              "value": "={{ $json.email }}",
+              "type": "string"
+            },
+            {
+              "id": "f",
+              "name": "firstName",
+              "value": "={{ $json.first_name || 'there' }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "f3c30003-0003-4c03-9d03-3e03f03a0003",
+      "name": "Send welcome email",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2.1,
+      "position": [
+        520,
+        300
+      ],
+      "parameters": {
+        "sendTo": "={{ $json.email }}",
+        "subject": "Welcome to our store!",
+        "emailType": "text",
+        "message": "=Hi {{ $json.firstName }},\n\nThanks for creating an account with us. We are glad to have you.\n\nReply to this email any time if you need a hand finding something.\n\nSee you soon.",
+        "options": {}
+      },
+      "credentials": {
+        "gmailOAuth2": {
+          "id": "YOUR_GMAIL_CREDENTIAL_ID",
+          "name": "Your Gmail account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "New Shopify customer": {
+      "main": [
+        [
+          {
+            "node": "Prepare welcome",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare welcome": {
+      "main": [
+        [
+          {
+            "node": "Send welcome email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "UTC"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": []
+}

--- a/Other_Integrations_and_Use_Cases/Shopify new order to Google Sheets.json
+++ b/Other_Integrations_and_Use_Cases/Shopify new order to Google Sheets.json
@@ -1,0 +1,158 @@
+{
+  "name": "Shopify New Order to Google Sheets (Free Starter)",
+  "nodes": [
+    {
+      "id": "aa000002-2222-4a22-9b22-000000000022",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -40,
+        40
+      ],
+      "parameters": {
+        "content": "## Shopify → Google Sheets order log\n\nAppends every new Shopify order as a row: Order, Customer, Email, Total, Date.\n\n**Setup**\n1. Create a sheet with headers: Order, Customer, Email, Total, Date.\n2. Add your Shopify Admin API and Google Sheets credentials.\n3. Point the Sheets node at your document, then save and activate.\n\nGuide: https://www.easyworkflows.net/shopify-new-orders-to-google-sheets-n8n/",
+        "height": 240,
+        "width": 760,
+        "color": 4
+      }
+    },
+    {
+      "id": "f2b20001-0001-4b01-8c01-2d01e01f0001",
+      "name": "New Shopify order",
+      "type": "n8n-nodes-base.shopifyTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        300
+      ],
+      "parameters": {
+        "topic": "orders/create",
+        "authentication": "accessToken"
+      },
+      "credentials": {
+        "shopifyAccessTokenApi": {
+          "id": "YOUR_SHOPIFY_CREDENTIAL_ID",
+          "name": "Your Shopify account"
+        }
+      }
+    },
+    {
+      "id": "f2b20002-0002-4b02-8c02-2d02e02f0002",
+      "name": "Map order fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        260,
+        300
+      ],
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "o",
+              "name": "Order",
+              "value": "={{ $json.name }}",
+              "type": "string"
+            },
+            {
+              "id": "c",
+              "name": "Customer",
+              "value": "={{ $json.customer ? $json.customer.first_name + ' ' + $json.customer.last_name : 'Guest checkout' }}",
+              "type": "string"
+            },
+            {
+              "id": "e",
+              "name": "Email",
+              "value": "={{ $json.email || ($json.customer ? $json.customer.email : '') }}",
+              "type": "string"
+            },
+            {
+              "id": "t",
+              "name": "Total",
+              "value": "={{ $json.total_price }}",
+              "type": "number"
+            },
+            {
+              "id": "d",
+              "name": "Date",
+              "value": "={{ $json.created_at }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "f2b20003-0003-4b03-8c03-2d03e03f0003",
+      "name": "Append to Sheet",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        520,
+        300
+      ],
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "YOUR_SPREADSHEET_ID",
+          "mode": "id"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "gid=0",
+          "mode": "list",
+          "cachedResultName": "Sheet1"
+        },
+        "columns": {
+          "mappingMode": "autoMapInputData",
+          "value": {},
+          "matchingColumns": [],
+          "schema": []
+        },
+        "options": {}
+      },
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "YOUR_GOOGLE_SHEETS_CREDENTIAL_ID",
+          "name": "Your Google Sheets account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "New Shopify order": {
+      "main": [
+        [
+          {
+            "node": "Map order fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Map order fields": {
+      "main": [
+        [
+          {
+            "node": "Append to Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "UTC"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": []
+}

--- a/Other_Integrations_and_Use_Cases/Shopify new order to Telegram alert.json
+++ b/Other_Integrations_and_Use_Cases/Shopify new order to Telegram alert.json
@@ -1,0 +1,118 @@
+{
+  "name": "Shopify New Order Telegram Alert (Free Starter)",
+  "nodes": [
+    {
+      "id": "aa000001-1111-4a11-9b11-000000000011",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -40,
+        40
+      ],
+      "parameters": {
+        "content": "## Shopify → Telegram order alert\n\nPosts a Telegram message for every new Shopify order (number, customer, total).\n\n**Setup**\n1. Add your Shopify Admin API credential (2026 access-token method).\n2. Add your Telegram bot credential and set the chat ID.\n3. Save and activate — the webhook registers automatically.\n\nGuide: https://www.easyworkflows.net/shopify-alerts-on-telegram-n8n/",
+        "height": 240,
+        "width": 760,
+        "color": 4
+      }
+    },
+    {
+      "id": "f1a10001-0001-4a01-9b01-1c01d01e0001",
+      "name": "New Shopify order",
+      "type": "n8n-nodes-base.shopifyTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        300
+      ],
+      "parameters": {
+        "topic": "orders/create",
+        "authentication": "accessToken"
+      },
+      "credentials": {
+        "shopifyAccessTokenApi": {
+          "id": "YOUR_SHOPIFY_CREDENTIAL_ID",
+          "name": "Your Shopify account"
+        }
+      }
+    },
+    {
+      "id": "f1a10002-0002-4a02-9b02-1c02d02e0002",
+      "name": "Build message",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        260,
+        300
+      ],
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "msg",
+              "name": "message",
+              "value": "=🛒 New order {{ $json.name }}\nCustomer: {{ $json.customer ? $json.customer.first_name + ' ' + $json.customer.last_name : 'Guest checkout' }}\nTotal: {{ $json.total_price }} {{ $json.currency }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "f1a10003-0003-4a03-9b03-1c03d03e0003",
+      "name": "Send Telegram alert",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        520,
+        300
+      ],
+      "parameters": {
+        "chatId": "YOUR_TELEGRAM_CHAT_ID",
+        "text": "={{ $json.message }}",
+        "additionalFields": {}
+      },
+      "credentials": {
+        "telegramApi": {
+          "id": "YOUR_TELEGRAM_CREDENTIAL_ID",
+          "name": "Your Telegram account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "New Shopify order": {
+      "main": [
+        [
+          {
+            "node": "Build message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build message": {
+      "main": [
+        [
+          {
+            "node": "Send Telegram alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "UTC"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false
+  },
+  "tags": []
+}

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Explore 13 social media automation templates for n8n covering Instagram, Twitter
 
 ### What other n8n integration templates are available?
 
-This section includes 45 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pennylane invoice automation, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
+This section includes 48 additional n8n integration templates covering a wide range of platforms and use cases. Highlights include API schema extraction, Pennylane invoice automation, Pinterest analysis with AI, SIEM alert enrichment with MITRE ATT&CK, Bitrix24 chatbots, GitLab code review with ChatGPT, LINE assistant integration, Spotify playlist archiving, Zoom meeting AI assistants, Siri AI agents via Apple Shortcuts, and Todoist inbox organization.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -485,6 +485,9 @@ This section includes 45 additional n8n integration templates covering a wide ra
 | Generate Seedance videos with Vancine API and bounded polling | Submits a Seedance video generation task, polls its asynchronous status, and handles completion, failure, and bounded timeout paths. | Engineering | [Link to Template](Other_Integrations_and_Use_Cases/Generate%20Seedance%20videos%20with%20Vancine%20API%20and%20bounded%20polling.json) |
 | Issue a Verifiable Certificate (Attestify API) | POST recipient and course data to a free API and receive a permanent, tamper-evident public verify page (Ed25519-signed — change one character and verification fails). Core HTTP node; no API key, no signup. | Education/Ops | [Link to Template](Other_Integrations_and_Use_Cases/Issue%20a%20verifiable%20certificate%20(Attestify).json) |
 | Transport Request Intake Lite | Free n8n workflow for normalizing a simple transport request and validating required fields. | Ops/Sales | [Link to Template](Other_Integrations_and_Use_Cases/Transport_Request_Intake_Lite.json) |
+| Shopify new order to Telegram alert | Sends a Telegram message the moment a new Shopify order is placed, with the order number, customer, and total. | E-commerce/Sales | [Link to Template](Other_Integrations_and_Use_Cases/Shopify%20new%20order%20to%20Telegram%20alert.json) |
+| Shopify new order to Google Sheets | Appends every new Shopify order as a row in a Google Sheet (order, customer, email, total, date) for an always-current order log. | E-commerce/Ops | [Link to Template](Other_Integrations_and_Use_Cases/Shopify%20new%20order%20to%20Google%20Sheets.json) |
+| Shopify new customer welcome email | Emails a welcome message from your own Gmail whenever a customer creates an account in your Shopify store. | E-commerce/Marketing | [Link to Template](Other_Integrations_and_Use_Cases/Shopify%20new%20customer%20welcome%20email.json) |
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />
 <small>* Referral link — this project receives a commission on eligible purchases.</small>


### PR DESCRIPTION
Adds three free, tested Shopify starter workflows. The list has a WooCommerce entry but no Shopify workflows yet, so these fill an ecommerce gap:

- Shopify new order to Telegram alert
- Shopify new order to Google Sheets
- Shopify new customer welcome email

Each is a valid n8n export, imports cleanly on current n8n, uses placeholder credentials only (no secrets), and includes an on-canvas Sticky Note with setup steps. Placed in "Other Integrations & Use Cases" per CONTRIBUTING (happy to open a "New Category: Shopify / E-commerce" issue if you'd prefer a dedicated section alongside WooCommerce).