### PR TITLE
Add n8n Silent Workflow Check template

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Find 5 database and storage automation templates for n8n. Chat with PostgreSQL u
 
 ### What n8n templates are available for DevOps and server automation?
 
-This section includes 6 DevOps and reliability templates for n8n. Audit a public page and build an implementation acceptance pack, trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely, watch disk usage across mountpoints, diagnose failed n8n execution JSON without connecting to a live instance, or get a Telegram alert only when a site's up/down state changes.
+This section includes 7 DevOps and reliability templates for n8n. Audit a public page and build an implementation acceptance pack, trigger Linux system updates via authenticated webhooks over SSH, control Docker Compose services remotely, watch disk usage across mountpoints, diagnose failed n8n execution JSON without connecting to a live instance, find active workflows that stopped running altogether, or get a Telegram alert only when a site's up/down state changes.
 
 | Title | Description | Department | Link |
 |-------|-------------|------------|------|
@@ -292,6 +292,7 @@ This section includes 6 DevOps and reliability templates for n8n. Audit a public
 | n8n Failed Execution Doctor | Diagnose exported failed n8n execution data locally, identify the failing node, classify common root causes such as 401/403, 429, timeouts, network, invalid input, and expression errors, and return a focused next diagnostic step. No external API key or LLM required. | Engineering | [Link to Template](devops/n8n-failed-execution-doctor.json) |
 | Uptime Ping Alert | Pings a URL every 5 minutes and notifies Telegram only when the up/down state actually changes (no repeated alerts while it stays down). No external API key beyond a Telegram bot token. | SSH Tools | [Link to Template](devops/uptime-ping-alert.json) |
 | GitHub Stars and Dev.to Engagement Monitor | Checks GitHub repo stars/forks/open issues and dev.to article reactions/comments on a schedule, compiling them into one record per run — for tracking whether anyone noticed what you shipped without opening five tabs. Easy to extend: duplicate an HTTP node per repo/article you want to track. | Marketing | [Link to Template](devops/GitHub%20Stars%20and%20Dev.to%20Engagement%20Monitor.json) |
+| n8n Silent Workflow Check | Finds workflows that are active but have not run — the failure that produces no failed execution, so an error workflow never fires for it. Compares every active workflow against its last execution on a schedule and returns the ones quiet longer than your threshold. No external API key beyond an n8n API key. | Engineering | [Link to Template](devops/n8n%20Silent%20Workflow%20Check.json) |
 
 > 🚀 **Automate any workflow.** [Start an n8n Cloud trial →](https://n8n.partnerlinks.io/h1pwwf5m4toe)
 <br />

--- a/devops/n8n Silent Workflow Check.json
+++ b/devops/n8n Silent Workflow Check.json
@@ -1,0 +1,164 @@
+{
+  "name": "n8n Silent Workflow Check",
+  "id": "duskwatchSilentCheck",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Silent workflow check\n\nFinds workflows that are **active but have not run** — the failure mode that produces no failed execution and therefore no error workflow alert.\n\n### Setup (2 minutes)\n1. In n8n: **Settings → n8n API → Create an API key**.\n2. On **Get workflows**, create a *Header Auth* credential:\n   - Name: `X-N8N-API-KEY`\n   - Value: your API key\n   Reuse the same credential on **Get executions**.\n3. In **Configuration**, set `baseUrl` to your n8n address (no trailing slash) and `staleHours` to how long silence is still normal.\n4. Attach your own alert node after **Find silent workflows**.\n\n### The catch\nThis workflow lives inside the instance it watches. If that instance is down, restarting, or its\nschedule triggers did not re-register, this check does not run either — and its silence looks\nexactly like everything being fine.\n\nThat is the one failure it cannot cover. Watching from outside is the only thing that does:\nhttps://duskwatch.me/checklist?ref=template",
+        "height": 620,
+        "width": 460
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000001",
+      "name": "Read me",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -460,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "triggerAtHour": 8
+            }
+          ]
+        }
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000002",
+      "name": "Every morning",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        40,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "baseUrl",
+              "value": "https://n8n.example.com",
+              "type": "string"
+            },
+            {
+              "id": "a2",
+              "name": "staleHours",
+              "value": 26,
+              "type": "number"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000003",
+      "name": "Configuration",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        260,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.baseUrl }}/api/v1/workflows?limit=250",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000004",
+      "name": "Get workflows",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        480,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{ $('Configuration').first().json.baseUrl }}/api/v1/executions?limit=250",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000005",
+      "name": "Get executions",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        700,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "const cfg = $('Configuration').first().json;\nconst stunden = Number(cfg.staleHours) || 24;\n\nconst workflows = ($('Get workflows').first().json.data || []).filter((w) => w.active && !w.isArchived);\nconst executions = $('Get executions').first().json.data || [];\n\n// Letzter Lauf je Workflow. Das Fenster reicht nur so weit zurueck wie limit=250 —\n// bei sehr vielen Ausfuehrungen kann ein stiller Workflow dadurch uebersehen werden.\nconst zuletzt = new Map();\nfor (const e of executions) {\n  const id = String(e.workflowId);\n  const t = new Date(e.startedAt || e.createdAt).getTime();\n  if (!Number.isFinite(t)) continue;\n  if (!zuletzt.has(id) || t > zuletzt.get(id)) zuletzt.set(id, t);\n}\n\nconst jetzt = Date.now();\nconst grenze = jetzt - stunden * 3600 * 1000;\nconst still = [];\n\nfor (const w of workflows) {\n  const t = zuletzt.get(String(w.id));\n  if (t === undefined) {\n    still.push({ workflow: w.name, workflowId: w.id, lastRun: null, hoursSilent: null, note: 'no execution in the window' });\n  } else if (t < grenze) {\n    still.push({ workflow: w.name, workflowId: w.id, lastRun: new Date(t).toISOString(), hoursSilent: Math.round((jetzt - t) / 3600000), note: 'active but stalled' });\n  }\n}\n\nif (still.length === 0) return [{ json: { silent: 0, activeChecked: workflows.length } }];\nreturn still.map((json) => ({ json }));"
+      },
+      "id": "8f1c0a10-0000-4000-8000-000000000006",
+      "name": "Find silent workflows",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        920,
+        100
+      ]
+    }
+  ],
+  "connections": {
+    "Every morning": {
+      "main": [
+        [
+          {
+            "node": "Configuration",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Configuration": {
+      "main": [
+        [
+          {
+            "node": "Get workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get workflows": {
+      "main": [
+        [
+          {
+            "node": "Get executions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get executions": {
+      "main": [
+        [
+          {
+            "node": "Find silent workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {}
+}


### PR DESCRIPTION
Adds one template to the **DevOps and server automation** category.

### What it does

Finds workflows that are **active but have not run**. That failure produces no failed execution, so an error workflow never fires for it — it happens after a restart that did not re-register the schedule trigger, or when someone toggles a workflow off while debugging and forgets it. The execution list looks clean and nothing has run for days.

The workflow reads the instance through the n8n API, takes every active workflow, finds its last execution, and returns the ones quiet longer than the threshold you set. Complements the existing **n8n Failed Execution Doctor**, which covers runs that failed; this one covers runs that never happened.

### Nodes

Schedule Trigger → Set (config) → HTTP Request (workflows) → HTTP Request (executions) → Code. Five nodes, attach your own alert node at the end. A sticky note in the canvas carries the setup steps.

### Checklist

- [x] Valid n8n workflow JSON, tested against n8n 2.37
- [x] No credentials, API keys or sensitive data in the file — auth is a Header Auth credential the user creates (`X-N8N-API-KEY`)
- [x] Added to `devops/`, file name matches the title
- [x] README row added to the DevOps table, category count and intro sentence updated
- [x] No external service or API key beyond the n8n API itself

### Known limits, stated in the sticky note

It lives inside the instance it watches, so it cannot cover the case where that instance is down or its triggers never re-armed. And it reads the last 250 executions, so on a busy instance a workflow that went quiet weeks ago can fall out of the window.

Source and README: https://github.com/Triponymous/n8n-silent-workflow-check (MIT)